### PR TITLE
GitHub SecretsをGC_プレフィックスに統一・CloudTasksClient OIDC設定改善 #82

### DIFF
--- a/.github/workflows/deploy-scheduler.yml
+++ b/.github/workflows/deploy-scheduler.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 env:
-  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  SCHEDULER_SA_EMAIL: ${{ secrets.SCHEDULER_SA_EMAIL }}
+  GCP_PROJECT_ID: ${{ secrets.GC_PROJECT_ID }}
+  SCHEDULER_SA_EMAIL: ${{ secrets.GC_SA_SCHEDULER }}
 
 jobs:
   deploy-scheduler:
@@ -24,7 +24,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY_CICD }}
+          credentials_json: ${{ secrets.GC_SA_CICID }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
@@ -33,10 +33,8 @@ jobs:
 
       - name: Deploy Cloud Scheduler Job
         run: |
-          # Get Cloud Run URL safely
-          SERVICE_URL=$(gcloud run services describe "urawa-support-hub" \
-            --region="asia-northeast1" \
-            --format='value(status.url)' 2>/dev/null)
+          # Use Cloud Run URL from GitHub Secrets
+          SERVICE_URL="${{ secrets.CLOUD_RUN_URL }}"
 
           # Validate URL format and prerequisites
           if [ -z "$SERVICE_URL" ] || [ -z "${{ env.SCHEDULER_SA_EMAIL }}" ]; then

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -169,13 +169,13 @@ Create the scheduler service account **before** CI/CD deployment:
 export GC_PROJECT_ID=your-project-id
 
 # Create service account for scheduler
-gcloud iam service-accounts create urawa-scheduler \
-  --display-name="Urawa Support Hub Scheduler" \
+gcloud iam service-accounts create scheduler-sa \
+  --display-name="Scheduler Service Account" \
   --description="Service account for Cloud Scheduler to invoke Cloud Run"
 
 # Grant Cloud Run invoker permission
-gcloud run services add-iam-policy-binding urawa-support-hub \
-  --member="serviceAccount:urawa-scheduler@${GC_PROJECT_ID}.iam.gserviceaccount.com" \
+gcloud run services add-iam-policy-binding your-service-name \
+  --member="serviceAccount:scheduler-sa@${GC_PROJECT_ID}.iam.gserviceaccount.com" \
   --role="roles/run.invoker" \
   --region=asia-northeast1
 ```
@@ -185,7 +185,7 @@ gcloud run services add-iam-policy-binding urawa-support-hub \
 Add these secrets for automatic deployment:
 
 - `GC_PROJECT_ID`: Your GCP project ID
-- `GC_SA_SCHEDULER`: `urawa-scheduler@your-project-id.iam.gserviceaccount.com`
+- `GC_SA_SCHEDULER`: `scheduler-sa@your-project-id.iam.gserviceaccount.com`
 - `GC_SA_CICID`: CI/CD service account key (JSON)
 - `CLOUD_RUN_URL`: Your Cloud Run service URL
 
@@ -201,11 +201,11 @@ The scheduler deploys automatically via GitHub Actions when changes are pushed t
 ```bash
 # Set variables
 export GC_PROJECT_ID=your-project-id
-export GC_SA_SCHEDULER=urawa-scheduler@${GC_PROJECT_ID}.iam.gserviceaccount.com
+export GC_SA_SCHEDULER=scheduler-sa@${GC_PROJECT_ID}.iam.gserviceaccount.com
 export CLOUD_RUN_URL=your-cloud-run-service-url
 
 # Create scheduler job (05:00 JST daily)
-gcloud scheduler jobs create http daily-ticket-collection \
+gcloud scheduler jobs create http your-job-name \
   --location=asia-northeast1 \
   --schedule="0 20 * * *" \
   --time-zone="Asia/Tokyo" \
@@ -222,10 +222,10 @@ gcloud scheduler jobs create http daily-ticket-collection \
 
 ```bash
 # Check scheduler job
-gcloud scheduler jobs describe daily-ticket-collection --location=asia-northeast1
+gcloud scheduler jobs describe your-job-name --location=asia-northeast1
 
 # Test execution
-gcloud scheduler jobs run daily-ticket-collection --location=asia-northeast1
+gcloud scheduler jobs run your-job-name --location=asia-northeast1
 
 # Check logs
 gcloud logging read 'resource.type=cloud_scheduler_job' --limit=5

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -166,7 +166,7 @@ Create the scheduler service account **before** CI/CD deployment:
 
 ```bash
 # Set your project ID
-export GCP_PROJECT_ID=your-project-id
+export GC_PROJECT_ID=your-project-id
 
 # Create service account for scheduler
 gcloud iam service-accounts create urawa-scheduler \
@@ -175,7 +175,7 @@ gcloud iam service-accounts create urawa-scheduler \
 
 # Grant Cloud Run invoker permission
 gcloud run services add-iam-policy-binding urawa-support-hub \
-  --member="serviceAccount:urawa-scheduler@${GCP_PROJECT_ID}.iam.gserviceaccount.com" \
+  --member="serviceAccount:urawa-scheduler@${GC_PROJECT_ID}.iam.gserviceaccount.com" \
   --role="roles/run.invoker" \
   --region=asia-northeast1
 ```
@@ -184,9 +184,10 @@ gcloud run services add-iam-policy-binding urawa-support-hub \
 
 Add these secrets for automatic deployment:
 
-- `GCP_PROJECT_ID`: Your GCP project ID
-- `SCHEDULER_SA_EMAIL`: `urawa-scheduler@your-project-id.iam.gserviceaccount.com`
-- `GCP_SA_KEY_CICD`: CI/CD service account key (JSON)
+- `GC_PROJECT_ID`: Your GCP project ID
+- `GC_SA_SCHEDULER`: `urawa-scheduler@your-project-id.iam.gserviceaccount.com`
+- `GC_SA_CICID`: CI/CD service account key (JSON)
+- `CLOUD_RUN_URL`: Your Cloud Run service URL
 
 #### Automatic Deployment (Recommended)
 
@@ -199,9 +200,9 @@ The scheduler deploys automatically via GitHub Actions when changes are pushed t
 
 ```bash
 # Set variables
-export GCP_PROJECT_ID=your-project-id
-export SCHEDULER_SA_EMAIL=urawa-scheduler@${GCP_PROJECT_ID}.iam.gserviceaccount.com
-export CLOUD_RUN_URL=https://urawa-support-hub-xxx-an.a.run.app
+export GC_PROJECT_ID=your-project-id
+export GC_SA_SCHEDULER=urawa-scheduler@${GC_PROJECT_ID}.iam.gserviceaccount.com
+export CLOUD_RUN_URL=your-cloud-run-service-url
 
 # Create scheduler job (05:00 JST daily)
 gcloud scheduler jobs create http daily-ticket-collection \
@@ -214,7 +215,7 @@ gcloud scheduler jobs create http daily-ticket-collection \
   --message-body='{"source":"cloud-scheduler"}' \
   --attempt-deadline="300s" \
   --max-retry-attempts=3 \
-  --oidc-service-account-email="${SCHEDULER_SA_EMAIL}"
+  --oidc-service-account-email="${GC_SA_SCHEDULER}"
 ```
 
 #### Verification

--- a/src/infrastructure/clients/CloudTasksClient.ts
+++ b/src/infrastructure/clients/CloudTasksClient.ts
@@ -86,6 +86,7 @@ export class CloudTasksClient implements ICloudTasksClient {
         body: btoa(JSON.stringify(payload)),
         oidcToken: {
           serviceAccountEmail: Deno.env.get('CLOUD_TASKS_SERVICE_ACCOUNT'),
+          audience: targetUrl,
         },
       },
     };


### PR DESCRIPTION
## 概要

GitHub ActionsのシークレットをGC_プレフィックスに統一し、CloudTasksClientのOIDC認証設定を改善しました。

## 実装内容

### 1. GitHub Actionsワークフロー更新
- `GCP_PROJECT_ID` → `GC_PROJECT_ID`
- `SCHEDULER_SA_EMAIL` → `GC_SA_SCHEDULER`  
- `GCP_SA_KEY_CICD` → `GC_SA_CICID`
- Cloud Run URLを`CLOUD_RUN_URL`シークレットから取得するよう変更

### 2. CloudTasksClient改善
- OIDCトークンに`audience`フィールドを追加
- セキュリティ強化のための必須パラメータ設定

### 3. ドキュメント更新
- `docs/setup-guide.md`の環境変数名を新しい命名規則に更新
- GitHub Secrets設定手順を最新化

## テスト計画

- [x] Type check実行確認 (`deno check`)
- [x] Lint check実行確認 (`deno lint`)
- [x] CloudTasksClientのテスト成功確認
- [x] GitHub Actionsワークフローの構文検証

## セキュリティ考慮事項

- ハードコードされた認証情報なし
- すべての認証情報はGitHub Secretsで管理
- OIDC認証の完全性向上

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #82