### PR TITLE
Cloud Tasks構造化ログ統一とUTC時刻修正

### DIFF
--- a/src/infrastructure/services/notification/NotificationSchedulerService.ts
+++ b/src/infrastructure/services/notification/NotificationSchedulerService.ts
@@ -26,7 +26,7 @@ export class NotificationSchedulerService implements INotificationSchedulerServi
     const schedulingPromises = scheduledTimes.map(async ({ type, scheduledTime }) => {
       try {
         const enqueueParams: EnqueueTaskParams = {
-          taskId: `${ticket.id}-${type}`,
+          taskId: `${ticket.id}-${type}-${crypto.randomUUID()}`,
           payload: {
             ticketId: ticket.id,
             notificationType: type,

--- a/src/infrastructure/services/scraping/TestTicketHelper.ts
+++ b/src/infrastructure/services/scraping/TestTicketHelper.ts
@@ -20,9 +20,19 @@ export class TestTicketHelper {
   static async generateTestTickets(): Promise<Ticket[]> {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    tomorrow.setHours(10, 0, 0, 0); // 明日10:00
 
-    const matchDate = new Date(tomorrow);
+    // UTC時刻で明日10:00 JST（UTC 01:00）を作成
+    const tomorrowUTC = new Date(Date.UTC(
+      tomorrow.getFullYear(),
+      tomorrow.getMonth(),
+      tomorrow.getDate(),
+      1,
+      0,
+      0,
+      0, // UTC 01:00 = JST 10:00
+    ));
+
+    const matchDate = new Date(tomorrowUTC);
     matchDate.setDate(matchDate.getDate() + 14); // 試合は2週間後
 
     // 基本的なテストチケット（実データに近い形式）
@@ -32,7 +42,7 @@ export class TestTicketHelper {
       homeTeam: '川崎フロンターレ',
       awayTeam: '浦和レッズ',
       competition: 'J1リーグ',
-      saleStartDate: tomorrow,
+      saleStartDate: tomorrowUTC,
       venue: '等々力陸上競技場',
       ticketTypes: ['ビジター指定席大人', 'ビジター指定席小中'],
       ticketUrl: 'https://www.jleague-ticket.jp/test/perform/2528632/001',
@@ -46,8 +56,8 @@ export class TestTicketHelper {
     // 再スケジューリングテストモード
     if (Deno.env.get('ENABLE_TEST_RESCHEDULE') === 'true') {
       // 販売開始日を2時間前に変更したチケット（再スケジューリングテスト用）
-      const rescheduledSaleStart = new Date(tomorrow);
-      rescheduledSaleStart.setHours(rescheduledSaleStart.getHours() - 2);
+      const rescheduledSaleStart = new Date(tomorrowUTC);
+      rescheduledSaleStart.setUTCHours(rescheduledSaleStart.getUTCHours() - 2);
 
       const rescheduledTicket = await Ticket.createNew({
         matchName: '[TEST-RESCHEDULE] 川崎フロンターレ vs 浦和レッズ',

--- a/src/shared/logging/CloudLogger.ts
+++ b/src/shared/logging/CloudLogger.ts
@@ -84,6 +84,13 @@ export class CloudLogger {
   }
 
   /**
+   * WARNINGレベルログのエイリアス
+   */
+  static warn(message: string, payload?: CloudLoggingEntry['jsonPayload']): void {
+    this.warning(message, payload);
+  }
+
+  /**
    * ERRORレベルログ（エラー、個別処理失敗）
    */
   static error(message: string, payload?: CloudLoggingEntry['jsonPayload']): void {

--- a/src/shared/logging/types.ts
+++ b/src/shared/logging/types.ts
@@ -41,6 +41,8 @@ export interface LogContext {
   taskId?: string; // Cloud TasksのタスクID
   queueName?: string; // Cloud Tasksのキュー名
   targetUrl?: string; // Cloud Tasksのターゲットエンドポイント
+  // その他の任意のコンテキスト情報
+  [key: string]: unknown;
 }
 
 /**
@@ -70,10 +72,13 @@ export interface ProcessingMetrics {
  */
 export interface ErrorInfo {
   code?: ErrorCode | string; // エラーコード（ErrorCodesの定数を使用）
+  message?: string; // エラーメッセージ
   details?: string; // 詳細メッセージ
   stack?: string; // スタックトレース（開発環境のみ）
-  recoverable: boolean; // 回復可能かどうか
+  recoverable?: boolean; // 回復可能かどうか
   grpcCode?: unknown; // gRPCエラーコード
+  // その他の任意のエラー情報
+  [key: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
## 概要

- Cloud TasksClientの全ログを構造化ログ（CloudLogger）に統一
- TaskIdの一意性確保でCloud Tasks重複制約を回避
- TestTicketHelperのUTC時刻対応でタイムゾーン問題を解決
- ログ型定義の柔軟性向上

## 実装内容

### 1. Cloud Tasks構造化ログ統一
- CloudTasksClientの全`console.log`をCloudLoggerに変換
- タスク作成、API呼び出し、認証テスト、メタデータサーバーテストを構造化
- Cloud Tasks APIレスポンス情報（taskName, scheduleTime, createTime）を含む適切なログ出力

### 2. TaskId一意性確保
- NotificationSchedulerServiceでTaskIdにUUIDサフィックス追加
- `${ticket.id}-${type}-${crypto.randomUUID()}`で重複制約回避
- 既存の通知管理（cloudTaskId保存）には影響なし

### 3. UTC時刻修正
- TestTicketHelperでUTC時刻を明示的に作成
- JST 10:00 = UTC 01:00で正確な時刻設定
- 再スケジュールテストも`setUTCHours()`でUTC基準に統一

### 4. ログ型定義改善
- LogContextに`[key: string]: unknown`で柔軟性確保
- ErrorInfoに`message`プロパティ追加、`recoverable`をオプショナル化
- CloudLoggerに`warn`メソッドエイリアス追加

## テスト計画

- [x] TypeScript型チェック成功確認
- [x] CloudTasksClient構造化ログ出力検証
- [x] UTC時刻でのテストデータ作成確認
- [x] TaskId一意性によるCloud Tasks制約回避確認

🤖 Generated with [Claude Code](https://claude.ai/code)

Related to #119