### PR TITLE
Cloud Scheduler月次実行を月初20時に変更 #140

### DIFF
--- a/infrastructure/scheduler/monthly-summary-config.yaml
+++ b/infrastructure/scheduler/monthly-summary-config.yaml
@@ -4,7 +4,7 @@
 job:
   name: monthly-ticket-summary
   description: Monthly ticket summary for Urawa Reds supporters
-  schedule: '0 11 1 * *' # 11:00 UTC = 20:00 JST on 1st day of each month
+  schedule: '0 20 1 * *' # 20:00 JST on 1st day of each month
   timeZone: Asia/Tokyo
   attemptDeadline: 120s # 2 minutes (sufficient for summary generation)
 


### PR DESCRIPTION
## 概要

- Cloud Schedulerの月次チケット一覧送信タイミングを11:00 JSTから20:00 JSTに変更

## 実装内容

- `infrastructure/scheduler/monthly-summary-config.yaml`の修正
  - schedule: `0 11 1 * *` → `0 20 1 * *`に変更
  - コメントを正確な実行時刻に更新
- timeZone: Asia/Tokyo設定により、20:00 JSTで月次実行

## テスト計画

- [ ] 設定ファイルの変更内容確認済み
- [ ] cronスケジュール構文の妥当性確認済み
- [ ] タイムゾーン設定の一貫性確認済み

Closes #140