### PR TITLE
サンフレッチェ広島オフィシャルサイトチケット情報取得機能実装 #66

### DIFF
--- a/docs/issue-priority-roadmap.md
+++ b/docs/issue-priority-roadmap.md
@@ -2,7 +2,7 @@
 
 **Target**: Personal use MVP with minimal implementation\
 **Created**: 2025-08-22\
-**Updated**: 2025-09-21 (Issue #140, #137, #135, #131, #130, #129完了)\
+**Updated**: 2025-09-23 (Issue #119完了)\
 **Goal**: ✅ Launch MVP by 2025-09-30 (**完了**: 2025-09-16)
 
 ## Implementation Status Summary
@@ -212,13 +212,16 @@ Each issue is considered complete when:
 
 ### 📈 **現在の開発フェーズ**: Post-MVP改善・機能拡張
 
-### ✅ **最近完了したイシュー (2025-09-20)**:
+### ✅ **最近完了したイシュー (2025-09-23)**:
 
-- #101 - 月初チケット一覧送信機能実装（Cloud Scheduler + LINE通知）✅
+- #119 - 構造化ログへの統一とログ戦略の見直し: String(error)パターンを全て置き換え ✅
+- #140 - Cloud Scheduler月次実行を月初20時に変更 ✅
 - #137 - 通知システムの改善: sent_atの誤更新修正とupdated_at追加 ✅
 - #135 - notificationsテーブルの命名不整合を修正 ✅
 - #131 - LINEメッセージの試合日時と販売開始日時をJST表示に修正 ✅
+- #130 - PostgreSQL セキュリティパッチ適用のためのデータベースアップグレード ✅
 - #129 - notificationsテーブルのnotification_scheduledカラム冗長性解決 ✅
+- #101 - 月初チケット一覧送信機能実装（Cloud Scheduler + LINE通知）✅
 
 ## 🚨 Active Issues - 優先順位別
 

--- a/src/config/di.ts
+++ b/src/config/di.ts
@@ -19,6 +19,7 @@ import { NotificationService } from '@/infrastructure/services/notification/Noti
 import { CloudTasksClient } from '@/infrastructure/clients/CloudTasksClient.ts';
 import { LineClient } from '@/infrastructure/clients/LineClient.ts';
 import { JLeagueScrapingService } from '@/infrastructure/scraping/jleague/JLeagueScrapingService.ts';
+import { HiroshimaScrapingService } from '@/infrastructure/scraping/hiroshima/HiroshimaScrapingService.ts';
 import { TestJLeagueScrapingService } from '@/infrastructure/scraping/test/TestJLeagueScrapingService.ts';
 import { PlaywrightClient } from '@/infrastructure/clients/PlaywrightClient.ts';
 import { BrowserManager } from '@/infrastructure/services/scraping/shared/BrowserManager.ts';
@@ -69,8 +70,14 @@ export const createDependencies = () => {
     // 本番モード: 実際のスクレイピングサービスを使用
     const playwrightClient = new PlaywrightClient();
     const browserManager = new BrowserManager(playwrightClient);
+
+    // J-Leagueサイトスクレイピング
     const jleagueScrapingService = new JLeagueScrapingService(browserManager);
     scrapingServices.push(jleagueScrapingService);
+
+    // サンフレッチェ広島公式サイトスクレイピング（同じbrowserManagerを使用）
+    const hiroshimaScrapingService = new HiroshimaScrapingService(browserManager);
+    scrapingServices.push(hiroshimaScrapingService);
   }
 
   const ticketCollectionService = new TicketCollectionService(scrapingServices);

--- a/src/domain/entities/SaleStatusUtils.ts
+++ b/src/domain/entities/SaleStatusUtils.ts
@@ -1,4 +1,5 @@
 import { createJSTDateTime, toJSTDate } from '@/shared/utils/datetime.ts';
+import type { SaleStatus } from '@/domain/types/SaleStatus.ts';
 
 /**
  * J-Leagueシーズンを考慮した年判定ロジック
@@ -50,7 +51,7 @@ export function determineSaleStatus(
   saleStartDate: Date | undefined,
   saleEndDate: Date | undefined,
   scrapedAt: Date,
-): 'before_sale' | 'on_sale' | 'ended' {
+): SaleStatus {
   if (saleEndDate && scrapedAt > saleEndDate) {
     return 'ended';
   }
@@ -68,7 +69,7 @@ export function parseSaleDate(
 ): {
   saleStartDate?: Date;
   saleEndDate?: Date;
-  saleStatus: 'before_sale' | 'on_sale' | 'ended';
+  saleStatus: SaleStatus;
 } {
   const beforeSalePattern = /^(\d{2})\/(\d{2})\([月火水木金土日]\)(\d{2}):(\d{2})〜$/;
   const onSalePattern = /^〜(\d{2})\/(\d{2})\([月火水木金土日]\)(\d{2}):(\d{2})$/;

--- a/src/domain/entities/Ticket.ts
+++ b/src/domain/entities/Ticket.ts
@@ -1,6 +1,7 @@
 import { NotificationType, shouldSendNotificationAtTime } from './NotificationTypes.ts';
 import { DataQuality, determineDataQuality } from './DataQuality.ts';
 import { formatDateOnly } from '@/shared/utils/datetime.ts';
+import type { SaleStatus } from '@/domain/types/SaleStatus.ts';
 import fastDeepEqual from 'fast-deep-equal';
 
 interface TicketProps {
@@ -18,7 +19,7 @@ interface TicketProps {
   createdAt: Date;
   updatedAt: Date;
   scrapedAt: Date;
-  saleStatus?: 'before_sale' | 'on_sale' | 'ended';
+  saleStatus?: SaleStatus;
   notificationScheduled?: boolean;
 }
 
@@ -120,7 +121,7 @@ export class Ticket {
     return this.props.ticketUrl;
   }
 
-  get saleStatus(): 'before_sale' | 'on_sale' | 'ended' {
+  get saleStatus(): SaleStatus {
     return this.props.saleStatus ?? 'before_sale';
   }
 

--- a/src/domain/entities/__tests__/SaleStatusUtils.test.ts
+++ b/src/domain/entities/__tests__/SaleStatusUtils.test.ts
@@ -74,7 +74,7 @@ Deno.test('parseSaleDate should parse full range format correctly', () => {
   assertEquals(result.saleEndDate?.getDate(), 12);
 
   assertEquals(typeof result.saleStatus, 'string');
-  assertEquals(['before_sale', 'on_sale', 'ended'].includes(result.saleStatus!), true);
+  assertEquals(['before_sale', 'on_sale', 'sold_out', 'ended'].includes(result.saleStatus!), true);
 });
 
 Deno.test('parseSaleDate should throw error for unknown format', () => {

--- a/src/domain/types/SaleStatus.ts
+++ b/src/domain/types/SaleStatus.ts
@@ -1,0 +1,14 @@
+/**
+ * チケット販売状況の型定義
+ */
+export type SaleStatus = 'before_sale' | 'on_sale' | 'sold_out' | 'ended';
+
+/**
+ * 販売状況の日本語表示名
+ */
+export const SALE_STATUS_LABELS: Record<SaleStatus, string> = {
+  before_sale: '販売開始前',
+  on_sale: '販売中',
+  sold_out: '完売',
+  ended: '販売終了',
+} as const;

--- a/src/domain/types/__tests__/SaleStatus.test.ts
+++ b/src/domain/types/__tests__/SaleStatus.test.ts
@@ -1,0 +1,57 @@
+import { assertEquals } from 'std/assert/mod.ts';
+import { SALE_STATUS_LABELS } from '../SaleStatus.ts';
+import type { SaleStatus } from '../SaleStatus.ts';
+
+Deno.test('SaleStatus', async (t) => {
+  await t.step('SaleStatus型が正しい値を持つ', () => {
+    const validStatuses: SaleStatus[] = [
+      'before_sale',
+      'on_sale',
+      'sold_out',
+      'ended',
+    ];
+
+    // 型チェックはコンパイル時に行われるため、実行時に値が存在することを確認
+    validStatuses.forEach((status) => {
+      // SALE_STATUS_LABELSにすべてのステータスが定義されていることを確認
+      assertEquals(typeof SALE_STATUS_LABELS[status], 'string');
+    });
+  });
+
+  await t.step('SALE_STATUS_LABELSが正しい日本語ラベルを持つ', () => {
+    assertEquals(SALE_STATUS_LABELS.before_sale, '販売開始前');
+    assertEquals(SALE_STATUS_LABELS.on_sale, '販売中');
+    assertEquals(SALE_STATUS_LABELS.sold_out, '完売');
+    assertEquals(SALE_STATUS_LABELS.ended, '販売終了');
+  });
+
+  await t.step('SALE_STATUS_LABELSがすべてのSaleStatus値をカバーしている', () => {
+    const expectedKeys: SaleStatus[] = ['before_sale', 'on_sale', 'sold_out', 'ended'];
+    const actualKeys = Object.keys(SALE_STATUS_LABELS) as SaleStatus[];
+
+    assertEquals(actualKeys.length, expectedKeys.length);
+
+    expectedKeys.forEach((key) => {
+      assertEquals(actualKeys.includes(key), true, `SALE_STATUS_LABELSに${key}が含まれていない`);
+    });
+  });
+
+  await t.step('SALE_STATUS_LABELSの値がすべて文字列である', () => {
+    Object.values(SALE_STATUS_LABELS).forEach((label) => {
+      assertEquals(typeof label, 'string');
+      assertEquals(label.length > 0, true, 'ラベルが空文字列');
+    });
+  });
+
+  await t.step('SALE_STATUS_LABELSがreadonly（as constされている）', () => {
+    // TypeScriptのas constが正しく適用されていることを確認
+    // 実行時には変更可能だが、型レベルでreadonly
+    const labels = SALE_STATUS_LABELS;
+
+    // すべてのプロパティが存在することを確認
+    assertEquals('before_sale' in labels, true);
+    assertEquals('on_sale' in labels, true);
+    assertEquals('sold_out' in labels, true);
+    assertEquals('ended' in labels, true);
+  });
+});

--- a/src/infrastructure/repositories/types/UpsertResult.ts
+++ b/src/infrastructure/repositories/types/UpsertResult.ts
@@ -1,8 +1,9 @@
 import { Ticket } from '@/domain/entities/Ticket.ts';
+import type { SaleStatus } from '@/domain/types/SaleStatus.ts';
 
 export interface UpsertResult {
   ticket: Ticket;
   isNew: boolean;
   hasChanged: boolean;
-  previousSaleStatus?: 'before_sale' | 'on_sale' | 'ended';
+  previousSaleStatus?: SaleStatus;
 }

--- a/src/infrastructure/scraping/hiroshima/HiroshimaScrapingService.ts
+++ b/src/infrastructure/scraping/hiroshima/HiroshimaScrapingService.ts
@@ -1,0 +1,80 @@
+import { Ticket } from '@/domain/entities/Ticket.ts';
+import { ISiteScrapingService } from '../shared/interfaces/index.ts';
+import { IPage } from '@/infrastructure/clients/interfaces/IPlaywrightClient.ts';
+import { HIROSHIMA_SCRAPING_CONFIG } from '@/infrastructure/services/scraping/sources/official/hiroshima/HiroshimaConfig.ts';
+import { HiroshimaDataExtractor } from './extractor/HiroshimaDataExtractor.ts';
+import { HiroshimaDataParser } from './parser/HiroshimaDataParser.ts';
+import { IBrowserManager } from '@/infrastructure/services/scraping/shared/interfaces/IBrowserManager.ts';
+
+/**
+ * サンフレッチェ広島公式サイトスクレイピングサービス
+ * 浦和レッズのアウェイチケット情報を取得
+ */
+export class HiroshimaScrapingService implements ISiteScrapingService {
+  readonly serviceName = 'Hiroshima';
+
+  private readonly dataExtractor: HiroshimaDataExtractor;
+  private readonly dataParser: HiroshimaDataParser;
+  private readonly browserManager: IBrowserManager;
+
+  constructor(browserManager: IBrowserManager) {
+    this.dataExtractor = new HiroshimaDataExtractor(
+      HIROSHIMA_SCRAPING_CONFIG.schedulePageConfig,
+      HIROSHIMA_SCRAPING_CONFIG.urawaKeywords,
+    );
+    this.dataParser = new HiroshimaDataParser();
+    this.browserManager = browserManager;
+  }
+
+  async collectTickets(): Promise<Ticket[]> {
+    await this.browserManager.launch(HIROSHIMA_SCRAPING_CONFIG.timeouts.pageLoad);
+    try {
+      const page = await this.browserManager.createPage(
+        HIROSHIMA_SCRAPING_CONFIG.timeouts.elementWait,
+      );
+      await this.configurePage(page);
+
+      // サンフレッチェ広島公式サイトのスケジュールページにアクセス
+      await this.browserManager.navigateToPage(page, HIROSHIMA_SCRAPING_CONFIG.baseUrl);
+
+      // ページコンテンツの読み込みを待つ
+      await this.waitForContent(page);
+
+      // 浦和レッズ戦の情報を抽出（すべてアウェイチケット）
+      const rawTickets = await this.dataExtractor.extractTickets(page);
+
+      // 共通のTicket形式に変換
+      const tickets = await this.dataParser.parseMultipleToTickets(rawTickets);
+
+      // 警告をクリア
+      this.dataExtractor.getAndClearWarnings();
+
+      return tickets;
+    } finally {
+      await this.browserManager.close();
+    }
+  }
+
+  private async configurePage(page: IPage): Promise<void> {
+    // 日本語環境でアクセス
+    await page.setExtraHTTPHeaders({
+      'Accept-Language': 'ja-JP,ja;q=0.9,en;q=0.8',
+    });
+
+    // ビューポートサイズを設定
+    await page.setViewportSize({ width: 1280, height: 720 });
+  }
+
+  private async waitForContent(page: IPage): Promise<void> {
+    // テーブルコンテンツの読み込みを待つ
+    try {
+      await this.browserManager.waitForContent(
+        page,
+        HIROSHIMA_SCRAPING_CONFIG.schedulePageConfig.selectors.ticketContainer,
+        3000,
+      );
+    } catch {
+      // タイムアウトしても続行（コンテンツが存在しない可能性）
+    }
+  }
+}

--- a/src/infrastructure/scraping/hiroshima/__tests__/HiroshimaScrapingService.test.ts
+++ b/src/infrastructure/scraping/hiroshima/__tests__/HiroshimaScrapingService.test.ts
@@ -1,0 +1,29 @@
+import { assertEquals } from 'std/assert/mod.ts';
+import { HiroshimaScrapingService } from '../HiroshimaScrapingService.ts';
+import { MockBrowserManager } from '../../jleague/__tests__/mocks/MockBrowserManager.ts';
+
+Deno.test('HiroshimaScrapingService', async (t) => {
+  await t.step('serviceName が正しく設定されている', () => {
+    const mockBrowserManager = new MockBrowserManager();
+    const service = new HiroshimaScrapingService(mockBrowserManager);
+    assertEquals(service.serviceName, 'Hiroshima');
+  });
+
+  await t.step('constructor が正しく動作する', () => {
+    const mockBrowserManager = new MockBrowserManager();
+
+    // Should not throw error
+    const service = new HiroshimaScrapingService(mockBrowserManager);
+    assertEquals(service.serviceName, 'Hiroshima');
+    assertEquals(typeof service.collectTickets, 'function');
+  });
+
+  await t.step('インターフェースが正しく実装されている', () => {
+    const mockBrowserManager = new MockBrowserManager();
+    const service = new HiroshimaScrapingService(mockBrowserManager);
+
+    // ISiteScrapingServiceのプロパティが存在することを確認
+    assertEquals(typeof service.serviceName, 'string');
+    assertEquals(typeof service.collectTickets, 'function');
+  });
+});

--- a/src/infrastructure/scraping/hiroshima/extractor/HiroshimaDataExtractor.ts
+++ b/src/infrastructure/scraping/hiroshima/extractor/HiroshimaDataExtractor.ts
@@ -1,0 +1,285 @@
+import { IPage } from '@/infrastructure/clients/interfaces/IPlaywrightClient.ts';
+import {
+  HIROSHIMA_SCRAPING_CONFIG,
+  HiroshimaSchedulePageConfig,
+} from '@/infrastructure/services/scraping/sources/official/hiroshima/HiroshimaConfig.ts';
+import { HiroshimaRawTicketData } from '../types/HiroshimaTypes.ts';
+import { CloudLogger } from '@/shared/logging/CloudLogger.ts';
+import { LogCategory } from '@/shared/logging/types.ts';
+import type { ElementHandle } from 'playwright';
+
+/**
+ * サンフレッチェ広島公式サイトからのデータ抽出クラス
+ * 浦和レッズ戦のみを抽出（すべてアウェイチケット確定）
+ */
+export class HiroshimaDataExtractor {
+  private warnings: string[] = [];
+
+  constructor(
+    private readonly config: HiroshimaSchedulePageConfig,
+    private readonly urawaKeywords: string[],
+  ) {}
+
+  async extractTickets(page: IPage): Promise<HiroshimaRawTicketData[]> {
+    const tickets: HiroshimaRawTicketData[] = [];
+
+    try {
+      // テーブル行を取得
+      const rowElements = await this.getTableRows(page);
+
+      if (rowElements.length === 0) {
+        this.addWarning('No ticket rows found');
+        return tickets;
+      }
+
+      CloudLogger.info('Hiroshima ticket rows found', {
+        category: LogCategory.TICKET_COLLECTION,
+        context: {
+          stage: 'data_extraction',
+        },
+        metadata: {
+          source: 'hiroshima',
+          rowCount: rowElements.length,
+        },
+      });
+
+      // 各行からチケット情報を抽出（浦和レッズ戦のみ）
+      for (let i = 0; i < rowElements.length; i++) {
+        try {
+          const rowData = await this.extractRowData(rowElements[i]);
+          if (rowData && this.isUrawaMatch(rowData.opponent)) {
+            tickets.push(rowData);
+            CloudLogger.info('Urawa match found in Hiroshima schedule', {
+              category: LogCategory.TICKET_COLLECTION,
+              context: {
+                stage: 'data_extraction',
+              },
+              metadata: {
+                source: 'hiroshima',
+                opponent: rowData.opponent,
+                date: rowData.matchDate,
+                status: rowData.saleStatus,
+              },
+            });
+          }
+        } catch (error) {
+          this.addWarning(`Failed to extract data from row ${i}: ${error}`);
+        }
+      }
+
+      return tickets;
+    } catch (error) {
+      CloudLogger.error('Failed to extract Hiroshima tickets', {
+        category: LogCategory.TICKET_COLLECTION,
+        context: {
+          stage: 'data_extraction',
+        },
+        metadata: {
+          source: 'hiroshima',
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+      throw error;
+    }
+  }
+
+  private async getTableRows(page: IPage): Promise<ElementHandle[]> {
+    for (const selector of this.config.selectors.ticketContainer) {
+      try {
+        const elements = await page.$$(selector);
+        if (elements.length > 0) {
+          return elements;
+        }
+      } catch {
+        continue;
+      }
+    }
+    return [];
+  }
+
+  private async extractRowData(rowElement: ElementHandle): Promise<HiroshimaRawTicketData | null> {
+    try {
+      // 1番目のtdから試合情報を取得
+      const matchInfo = await this.extractMatchInfo(rowElement);
+      if (!matchInfo.date) {
+        return null;
+      }
+
+      // 会場情報が取得できない場合は警告
+      if (!matchInfo.venue) {
+        this.addWarning('Venue information not found');
+      }
+
+      // 対戦相手を取得（img要素のalt属性から）
+      const opponent = await this.extractOpponent(rowElement);
+      if (!opponent) {
+        return null;
+      }
+
+      // 販売状況を取得
+      const saleStatus = await this.extractText(rowElement, this.config.selectors.ticketStatus);
+      if (!saleStatus) {
+        this.addWarning('Sale status not found');
+        return null;
+      }
+
+      // 一般販売日を取得（6番目のtd）
+      const saleDate = await this.extractSaleDate(rowElement);
+
+      return {
+        matchDate: matchInfo.date!, // 既に null チェック済み
+        matchTime: matchInfo.time || undefined,
+        opponent,
+        venue: matchInfo.venue,
+        saleStatus,
+        ticketUrl: HIROSHIMA_SCRAPING_CONFIG.ticketPurchaseUrl, // 固定のチケット購入URL
+        saleDate,
+        ticketTypes: ['ビジター席'], // サンフレッチェ広島公式サイトなので確定でビジター席
+      };
+    } catch (error) {
+      this.addWarning(`Row data extraction failed: ${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * 1番目のtdから日付、時間、会場を抽出
+   * HTML例: "第36節<br>11.9 [日]<br>13:00K.O.<br>エディオンピースウイング広島"
+   */
+  private async extractMatchInfo(rowElement: ElementHandle): Promise<{
+    date: string | null;
+    time: string | null;
+    venue: string | null;
+  }> {
+    try {
+      const firstTd = await rowElement.$('td:first-child p');
+      if (!firstTd) {
+        return { date: null, time: null, venue: null };
+      }
+
+      const fullText = await firstTd.textContent();
+      if (!fullText) {
+        return { date: null, time: null, venue: null };
+      }
+
+      // テキストを行で分割
+      const lines = fullText.split('\n').map((line) => line.trim()).filter((line) => line);
+
+      let date = null;
+      let time = null;
+      let venue = null;
+
+      for (const line of lines) {
+        // 日付を抽出（例: "11.9 [日]"）
+        const dateMatch = line.match(/(\d{1,2}\.\d{1,2})\s*\[[^\]]+\]/);
+        if (dateMatch) {
+          date = dateMatch[1];
+          continue;
+        }
+
+        // 時間を抽出（例: "13:00K.O."）
+        const timeMatch = line.match(/(\d{1,2}:\d{2})K\.O\./);
+        if (timeMatch) {
+          time = timeMatch[1];
+          continue;
+        }
+
+        // 会場を抽出（エディオンピースウイング広島など）
+        if (
+          line.includes('エディオン') || line.includes('広島') ||
+          (!line.includes('節') && !line.includes('K.O.'))
+        ) {
+          venue = line;
+        }
+      }
+
+      return { date, time, venue };
+    } catch {
+      return { date: null, time: null, venue: null };
+    }
+  }
+
+  private async extractText(
+    rowElement: ElementHandle,
+    selectors: string[],
+  ): Promise<string | null> {
+    for (const selector of selectors) {
+      try {
+        const element = await rowElement.$(selector);
+        if (element) {
+          const text = await element.textContent();
+          if (text?.trim()) {
+            return text.trim();
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  }
+
+  private async extractOpponent(rowElement: ElementHandle): Promise<string | null> {
+    for (const selector of this.config.selectors.opponent) {
+      try {
+        const imgElement = await rowElement.$(selector);
+        if (imgElement) {
+          const alt = await imgElement.getAttribute('alt');
+          if (alt?.trim()) {
+            return alt.trim();
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * 6番目のtdから一般販売日を取得
+   * HTML例: "10/10(金)<br>12:00～"
+   */
+  private async extractSaleDate(rowElement: ElementHandle): Promise<string | undefined> {
+    try {
+      const saleTd = await rowElement.$('td:nth-child(6)');
+      if (!saleTd) {
+        return undefined;
+      }
+
+      const saleText = await saleTd.textContent();
+      if (!saleText?.trim()) {
+        return undefined;
+      }
+
+      return saleText.trim();
+    } catch {
+      return undefined;
+    }
+  }
+
+  private isUrawaMatch(opponent: string): boolean {
+    const lowerOpponent = opponent.toLowerCase();
+    return this.urawaKeywords.some((keyword) => lowerOpponent.includes(keyword.toLowerCase()));
+  }
+
+  private addWarning(message: string): void {
+    this.warnings.push(message);
+    CloudLogger.warn('Hiroshima data extraction warning', {
+      category: LogCategory.TICKET_COLLECTION,
+      context: {
+        stage: 'data_extraction',
+      },
+      metadata: {
+        source: 'hiroshima',
+        warning: message,
+      },
+    });
+  }
+
+  getAndClearWarnings(): string[] {
+    const currentWarnings = [...this.warnings];
+    this.warnings = [];
+    return currentWarnings;
+  }
+}

--- a/src/infrastructure/scraping/hiroshima/extractor/__tests__/HiroshimaDataExtractor.test.ts
+++ b/src/infrastructure/scraping/hiroshima/extractor/__tests__/HiroshimaDataExtractor.test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from 'std/assert/mod.ts';
+import { HiroshimaDataExtractor } from '../HiroshimaDataExtractor.ts';
+import { HIROSHIMA_SCRAPING_CONFIG } from '@/infrastructure/services/scraping/sources/official/hiroshima/HiroshimaConfig.ts';
+import { MockPlaywrightClient } from '@/shared/testing/mocks/MockPlaywrightClient.ts';
+
+Deno.test('HiroshimaDataExtractor', async (t) => {
+  const extractor = new HiroshimaDataExtractor(
+    HIROSHIMA_SCRAPING_CONFIG.schedulePageConfig,
+    HIROSHIMA_SCRAPING_CONFIG.urawaKeywords,
+  );
+
+  await t.step('extractTickets メソッドが呼び出し可能', async () => {
+    const mockClient = new MockPlaywrightClient();
+    await mockClient.launch();
+    const mockPage = await mockClient.createPage();
+
+    // Empty data case - should return empty array without errors
+    const tickets = await extractor.extractTickets(mockPage);
+    assertEquals(Array.isArray(tickets), true);
+  });
+
+  await t.step('constructor が正しく動作する', () => {
+    // Should not throw error
+    const newExtractor = new HiroshimaDataExtractor(
+      HIROSHIMA_SCRAPING_CONFIG.schedulePageConfig,
+      HIROSHIMA_SCRAPING_CONFIG.urawaKeywords,
+    );
+    assertEquals(typeof newExtractor, 'object');
+  });
+
+  await t.step('getAndClearWarnings が動作する', async () => {
+    const mockClient = new MockPlaywrightClient();
+    await mockClient.launch();
+    const mockPage = await mockClient.createPage();
+
+    await extractor.extractTickets(mockPage);
+    const warnings = extractor.getAndClearWarnings();
+    assertEquals(Array.isArray(warnings), true);
+
+    // 警告がクリアされることを確認
+    const warningsAfterClear = extractor.getAndClearWarnings();
+    assertEquals(warningsAfterClear.length, 0);
+  });
+});

--- a/src/infrastructure/scraping/hiroshima/parser/HiroshimaDataParser.ts
+++ b/src/infrastructure/scraping/hiroshima/parser/HiroshimaDataParser.ts
@@ -1,0 +1,251 @@
+import { Ticket } from '@/domain/entities/Ticket.ts';
+import { HiroshimaRawTicketData } from '../types/HiroshimaTypes.ts';
+import { CloudLogger } from '@/shared/logging/CloudLogger.ts';
+import { LogCategory } from '@/shared/logging/types.ts';
+import type { SaleStatus } from '@/domain/types/SaleStatus.ts';
+
+/**
+ * サンフレッチェ広島のデータを共通のTicket形式に変換
+ * サンフレッチェ広島サイト固有のフォーマットに対応
+ */
+export class HiroshimaDataParser {
+  async parseMultipleToTickets(rawTickets: HiroshimaRawTicketData[]): Promise<Ticket[]> {
+    const tickets: Ticket[] = [];
+
+    for (const rawTicket of rawTickets) {
+      try {
+        const ticket = await this.parseToTicket(rawTicket);
+        if (ticket) {
+          tickets.push(ticket);
+        }
+      } catch (error) {
+        CloudLogger.error('Failed to parse Hiroshima ticket', {
+          category: LogCategory.TICKET_COLLECTION,
+          context: {
+            stage: 'data_parsing',
+          },
+          metadata: {
+            source: 'hiroshima',
+            rawTicket,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        });
+      }
+    }
+
+    return tickets;
+  }
+
+  private async parseToTicket(rawTicket: HiroshimaRawTicketData): Promise<Ticket | null> {
+    try {
+      // 試合日時をパース（サンフレッチェ広島サイト固有のフォーマット）
+      const matchDate = this.parseMatchDate(rawTicket.matchDate, rawTicket.matchTime);
+      if (!matchDate) {
+        CloudLogger.warn('Failed to parse match date', {
+          category: LogCategory.TICKET_COLLECTION,
+          context: {
+            stage: 'data_parsing',
+          },
+          metadata: {
+            source: 'hiroshima',
+            date: rawTicket.matchDate,
+            time: rawTicket.matchTime,
+          },
+        });
+        return null;
+      }
+
+      // 販売開始日をパース（もしあれば）
+      const saleStartDate = this.parseSaleDate(rawTicket.saleDate);
+
+      // 販売状況を判定
+      const saleStatus = this.determineSaleStatus(rawTicket.saleStatus);
+
+      // チケットタイトルを生成（アウェイ戦なので「サンフレッチェ広島 vs 浦和レッズ」）
+      const ticketTitle = `サンフレッチェ広島 vs 浦和レッズ`;
+
+      // 大会名を判定（デフォルトはJ1リーグ）
+      const competition = this.normalizeCompetition(rawTicket.competition);
+
+      const ticket = await Ticket.createNew({
+        matchName: ticketTitle,
+        competition: competition,
+        matchDate: matchDate,
+        venue: rawTicket.venue || undefined,
+        saleStartDate: saleStartDate,
+        saleStatus: saleStatus,
+        ticketUrl: rawTicket.ticketUrl || '',
+        ticketTypes: rawTicket.ticketTypes,
+        homeTeam: 'サンフレッチェ広島', // ホームチーム
+        awayTeam: '浦和レッズ', // アウェイチーム
+        scrapedAt: new Date(),
+      });
+
+      return ticket;
+    } catch (error) {
+      CloudLogger.error('Error parsing Hiroshima ticket', {
+        category: LogCategory.TICKET_COLLECTION,
+        context: {
+          stage: 'data_parsing',
+        },
+        metadata: {
+          source: 'hiroshima',
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+      return null;
+    }
+  }
+
+  /**
+   * サンフレッチェ広島サイト固有の日付フォーマットをパース
+   * 例: "2.23 [日・祝]", "10.26 [土]"
+   */
+  private parseMatchDate(dateStr: string, timeStr?: string): Date | null {
+    try {
+      const currentYear = new Date().getFullYear();
+
+      // 日付から月日を抽出（例: "2.23 [日・祝]" -> "2.23"）
+      const dateMatch = dateStr.match(/(\d{1,2})\.(\d{1,2})/);
+      if (!dateMatch) {
+        return null;
+      }
+
+      const month = parseInt(dateMatch[1], 10);
+      const day = parseInt(dateMatch[2], 10);
+
+      // 時間をパース（例: "14:00 K.O." -> "14:00"）
+      // 時間が取得できない場合は不正確なデフォルト値は使用しない
+      if (!timeStr) {
+        return null;
+      }
+
+      const timeMatch = timeStr.match(/(\d{1,2}):(\d{2})/);
+      if (!timeMatch) {
+        return null;
+      }
+
+      const hour = parseInt(timeMatch[1], 10);
+      const minute = parseInt(timeMatch[2], 10);
+
+      // 年を決定（現在月より前の月なら来年）
+      const now = new Date();
+      let year = currentYear;
+      if (month < now.getMonth() + 1) {
+        year = currentYear + 1;
+      }
+
+      // JST時刻として作成
+      const jstDate = new Date(year, month - 1, day, hour, minute, 0, 0);
+
+      if (isNaN(jstDate.getTime())) {
+        return null;
+      }
+
+      return jstDate;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 販売開始日をパース（サンフレッチェ広島サイト固有）
+   * 例: "10/10(金)<br>12:00～" または "10/10(金) 12:00～"
+   */
+  private parseSaleDate(saleDateStr?: string): Date | null {
+    if (!saleDateStr) {
+      return null;
+    }
+
+    try {
+      // 日付を抽出（例: "10/10"）
+      const dateMatch = saleDateStr.match(/(\d{1,2})\/(\d{1,2})/);
+      if (!dateMatch) {
+        return null;
+      }
+
+      const month = parseInt(dateMatch[1], 10);
+      const day = parseInt(dateMatch[2], 10);
+
+      // 時間を抽出（例: "12:00"）
+      const timeMatch = saleDateStr.match(/(\d{1,2}):(\d{2})/);
+      if (!timeMatch) {
+        // 時間が取得できない場合はnullを返す（デフォルト値は使わない）
+        return null;
+      }
+
+      const hour = parseInt(timeMatch[1], 10);
+      const minute = parseInt(timeMatch[2], 10);
+
+      const currentYear = new Date().getFullYear();
+      const saleDate = new Date(currentYear, month - 1, day, hour, minute, 0, 0);
+
+      if (isNaN(saleDate.getTime())) {
+        return null;
+      }
+
+      return saleDate;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 販売状況を判定（サンフレッチェ広島サイト固有）
+   */
+  private determineSaleStatus(statusStr: string): SaleStatus | undefined {
+    const lowerStatus = statusStr.toLowerCase();
+
+    // キーワードによる判定
+    const soldOutKeywords = ['完売', '売り切れ', '全席種完売'];
+    const endedKeywords = ['販売終了', '発売終了', '終了'];
+    const onSaleKeywords = ['販売中', '発売中', 'WEBで購入', '購入可能'];
+    const beforeSaleKeywords = ['販売開始前', '発売前', '販売予定'];
+
+    switch (true) {
+      case soldOutKeywords.some((keyword) => lowerStatus.includes(keyword)):
+        return 'sold_out';
+
+      case endedKeywords.some((keyword) => lowerStatus.includes(keyword)):
+        return 'ended';
+
+      case onSaleKeywords.some((keyword) => lowerStatus.includes(keyword)):
+        return 'on_sale';
+
+      case beforeSaleKeywords.some((keyword) => lowerStatus.includes(keyword)):
+        return 'before_sale';
+
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * 大会名を正規化
+   */
+  private normalizeCompetition(competition?: string): string {
+    if (!competition) {
+      return 'J1リーグ';
+    }
+
+    // サンフレッチェ広島サイトの表記を統一
+    const competitionMap: Record<string, string> = {
+      'J1': 'J1リーグ',
+      'J1リーグ': 'J1リーグ',
+      '明治安田J1': 'J1リーグ',
+      'ルヴァン': 'ルヴァンカップ',
+      'ルヴァンカップ': 'ルヴァンカップ',
+      '天皇杯': '天皇杯',
+      'ACL': 'ACLE',
+      'ACLE': 'ACLE',
+    };
+
+    for (const [key, value] of Object.entries(competitionMap)) {
+      if (competition.includes(key)) {
+        return value;
+      }
+    }
+
+    return competition;
+  }
+}

--- a/src/infrastructure/scraping/hiroshima/parser/__tests__/HiroshimaDataParser.test.ts
+++ b/src/infrastructure/scraping/hiroshima/parser/__tests__/HiroshimaDataParser.test.ts
@@ -1,0 +1,247 @@
+import { assertEquals, assertExists } from 'std/assert/mod.ts';
+import { HiroshimaDataParser } from '../HiroshimaDataParser.ts';
+import type { HiroshimaRawTicketData } from '../../types/HiroshimaTypes.ts';
+
+Deno.test('HiroshimaDataParser', async (t) => {
+  const parser = new HiroshimaDataParser();
+
+  await t.step('サンフレッチェ広島の生データを正しいTicket形式に変換する', async () => {
+    const rawTicketData: HiroshimaRawTicketData = {
+      matchDate: '11.9',
+      matchTime: '13:00',
+      opponent: '浦和レッズ',
+      venue: 'エディオンピースウイング広島',
+      saleStatus: '販売中',
+      ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+      saleDate: '10/10(金) 12:00～',
+      ticketTypes: ['ビジター席'],
+    };
+
+    const tickets = await parser.parseMultipleToTickets([rawTicketData]);
+
+    assertEquals(tickets.length, 1);
+    const ticket = tickets[0];
+
+    assertEquals(ticket.matchName, 'サンフレッチェ広島 vs 浦和レッズ');
+    assertEquals(ticket.competition, 'J1リーグ');
+    assertEquals(ticket.venue, 'エディオンピースウイング広島');
+    assertEquals(ticket.saleStatus, 'on_sale');
+    assertEquals(ticket.ticketUrl, 'https://ticket.sanfrecce.co.jp/');
+    assertEquals(ticket.ticketTypes, ['ビジター席']);
+    assertEquals(ticket.homeTeam, 'サンフレッチェ広島');
+    assertEquals(ticket.awayTeam, '浦和レッズ');
+    assertExists(ticket.matchDate);
+    assertExists(ticket.saleStartDate);
+    assertExists(ticket.scrapedAt);
+  });
+
+  await t.step('複数のチケットデータを処理する', async () => {
+    const rawTickets: HiroshimaRawTicketData[] = [
+      {
+        matchDate: '11.9',
+        matchTime: '13:00',
+        opponent: '浦和レッズ',
+        venue: 'エディオンピースウイング広島',
+        saleStatus: '販売中',
+        ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+        ticketTypes: ['ビジター席'],
+      },
+      {
+        matchDate: '12.15',
+        matchTime: '14:00',
+        opponent: '浦和レッズ',
+        venue: 'エディオンピースウイング広島',
+        saleStatus: '完売',
+        ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+        ticketTypes: ['ビジター席'],
+      },
+    ];
+
+    const tickets = await parser.parseMultipleToTickets(rawTickets);
+
+    assertEquals(tickets.length, 2);
+    assertEquals(tickets[0].saleStatus, 'on_sale');
+    assertEquals(tickets[1].saleStatus, 'sold_out');
+  });
+
+  await t.step('販売状況を正しくマップする', async () => {
+    const testCases: Array<{ input: string; expected: string }> = [
+      { input: '販売中', expected: 'on_sale' },
+      { input: '発売中', expected: 'on_sale' },
+      { input: '購入可能', expected: 'on_sale' },
+      { input: '完売', expected: 'sold_out' },
+      { input: '売り切れ', expected: 'sold_out' },
+      { input: '全席種完売', expected: 'sold_out' },
+      { input: '販売終了', expected: 'ended' },
+      { input: '発売終了', expected: 'ended' },
+      { input: '販売開始前', expected: 'before_sale' },
+      { input: '発売前', expected: 'before_sale' },
+    ];
+
+    for (const testCase of testCases) {
+      const rawTicketData: HiroshimaRawTicketData = {
+        matchDate: '11.9',
+        matchTime: '13:00',
+        opponent: '浦和レッズ',
+        venue: 'エディオンピースウイング広島',
+        saleStatus: testCase.input,
+        ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+        ticketTypes: ['ビジター席'],
+      };
+
+      const tickets = await parser.parseMultipleToTickets([rawTicketData]);
+      assertEquals(
+        tickets[0].saleStatus,
+        testCase.expected,
+        `販売状況 "${testCase.input}" が "${testCase.expected}" にマップされない`,
+      );
+    }
+  });
+
+  await t.step('日付パース - 正常ケース', async () => {
+    const testCases: Array<
+      {
+        date: string;
+        time: string;
+        expectedMonth: number;
+        expectedDay: number;
+        expectedHour: number;
+      }
+    > = [
+      { date: '11.9', time: '13:00', expectedMonth: 11, expectedDay: 9, expectedHour: 13 },
+      { date: '2.23', time: '14:00', expectedMonth: 2, expectedDay: 23, expectedHour: 14 },
+      { date: '10.26', time: '19:00', expectedMonth: 10, expectedDay: 26, expectedHour: 19 },
+    ];
+
+    for (const testCase of testCases) {
+      const rawTicketData: HiroshimaRawTicketData = {
+        matchDate: testCase.date,
+        matchTime: testCase.time,
+        opponent: '浦和レッズ',
+        venue: 'エディオンピースウイング広島',
+        saleStatus: '販売中',
+        ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+        ticketTypes: ['ビジター席'],
+      };
+
+      const tickets = await parser.parseMultipleToTickets([rawTicketData]);
+      assertEquals(tickets.length, 1);
+
+      const matchDate = tickets[0].matchDate;
+      assertEquals(matchDate.getMonth() + 1, testCase.expectedMonth);
+      assertEquals(matchDate.getDate(), testCase.expectedDay);
+      assertEquals(matchDate.getHours(), testCase.expectedHour);
+    }
+  });
+
+  await t.step('販売開始日のパース', async () => {
+    const testCases: Array<
+      { saleDate: string; expectedMonth: number; expectedDay: number; expectedHour: number }
+    > = [
+      { saleDate: '10/10(金) 12:00～', expectedMonth: 10, expectedDay: 10, expectedHour: 12 },
+      { saleDate: '11/15(水) 15:30～', expectedMonth: 11, expectedDay: 15, expectedHour: 15 },
+      { saleDate: '9/5(木) 09:00～', expectedMonth: 9, expectedDay: 5, expectedHour: 9 },
+    ];
+
+    for (const testCase of testCases) {
+      const rawTicketData: HiroshimaRawTicketData = {
+        matchDate: '11.9',
+        matchTime: '13:00',
+        opponent: '浦和レッズ',
+        venue: 'エディオンピースウイング広島',
+        saleStatus: '販売中',
+        ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+        saleDate: testCase.saleDate,
+        ticketTypes: ['ビジター席'],
+      };
+
+      const tickets = await parser.parseMultipleToTickets([rawTicketData]);
+      assertEquals(tickets.length, 1);
+
+      const saleStartDate = tickets[0].saleStartDate;
+      assertExists(saleStartDate);
+      assertEquals(saleStartDate!.getMonth() + 1, testCase.expectedMonth);
+      assertEquals(saleStartDate!.getDate(), testCase.expectedDay);
+      assertEquals(saleStartDate!.getHours(), testCase.expectedHour);
+    }
+  });
+
+  await t.step('大会名の正規化', async () => {
+    const rawTicketData: HiroshimaRawTicketData = {
+      matchDate: '11.9',
+      matchTime: '13:00',
+      opponent: '浦和レッズ',
+      venue: 'エディオンピースウイング広島',
+      saleStatus: '販売中',
+      ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+      ticketTypes: ['ビジター席'],
+      competition: '明治安田J1リーグ',
+    };
+
+    const tickets = await parser.parseMultipleToTickets([rawTicketData]);
+    assertEquals(tickets[0].competition, 'J1リーグ');
+  });
+
+  await t.step('不正なデータの場合はnullを返す', async () => {
+    const invalidRawTickets: HiroshimaRawTicketData[] = [
+      // 不正な日付フォーマット
+      {
+        matchDate: '無効な日付',
+        matchTime: '13:00',
+        opponent: '浦和レッズ',
+        venue: 'エディオンピースウイング広島',
+        saleStatus: '販売中',
+        ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+        ticketTypes: ['ビジター席'],
+      },
+      // 時間なし
+      {
+        matchDate: '11.9',
+        // matchTime なし
+        opponent: '浦和レッズ',
+        venue: 'エディオンピースウイング広島',
+        saleStatus: '販売中',
+        ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+        ticketTypes: ['ビジター席'],
+      },
+    ];
+
+    const tickets = await parser.parseMultipleToTickets(invalidRawTickets);
+    assertEquals(tickets.length, 0);
+  });
+
+  await t.step('販売開始日が不正な場合はnullになる', async () => {
+    const rawTicketData: HiroshimaRawTicketData = {
+      matchDate: '11.9',
+      matchTime: '13:00',
+      opponent: '浦和レッズ',
+      venue: 'エディオンピースウイング広島',
+      saleStatus: '販売中',
+      ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+      saleDate: '不正な日付形式',
+      ticketTypes: ['ビジター席'],
+    };
+
+    const tickets = await parser.parseMultipleToTickets([rawTicketData]);
+    assertEquals(tickets.length, 1);
+    assertEquals(tickets[0].saleStartDate, null);
+  });
+
+  await t.step('不明な販売状況の場合の処理', async () => {
+    const rawTicketData: HiroshimaRawTicketData = {
+      matchDate: '11.9',
+      matchTime: '13:00',
+      opponent: '浦和レッズ',
+      venue: 'エディオンピースウイング広島',
+      saleStatus: '不明な状況',
+      ticketUrl: 'https://ticket.sanfrecce.co.jp/',
+      ticketTypes: ['ビジター席'],
+    };
+
+    const tickets = await parser.parseMultipleToTickets([rawTicketData]);
+    assertEquals(tickets.length, 1);
+    // 不明な状況の場合、undefinedまたはデフォルト値が設定される
+    const saleStatus = tickets[0].saleStatus;
+    assertEquals(typeof saleStatus === 'string' || saleStatus === undefined, true);
+  });
+});

--- a/src/infrastructure/scraping/hiroshima/types/HiroshimaTypes.ts
+++ b/src/infrastructure/scraping/hiroshima/types/HiroshimaTypes.ts
@@ -1,0 +1,19 @@
+/**
+ * 広島スクレイピング用型定義
+ */
+
+/**
+ * 広島の生データ（スクレイピング直後の状態）
+ */
+export interface HiroshimaRawTicketData {
+  matchDate: string;
+  matchTime?: string;
+  opponent: string;
+  venue: string | null;
+  saleStatus: string;
+  ticketUrl?: string;
+  competition?: string;
+  enhancedMatchDateTime?: string;
+  saleDate?: string;
+  ticketTypes: string[];
+}

--- a/src/infrastructure/scraping/jleague/parser/JLeagueDataParser.ts
+++ b/src/infrastructure/scraping/jleague/parser/JLeagueDataParser.ts
@@ -6,6 +6,7 @@ import { JLeagueRawTicketData } from '../types/JLeagueTypes.ts';
 import { CloudLogger } from '@/shared/logging/CloudLogger.ts';
 import { ErrorCodes } from '@/shared/logging/ErrorCodes.ts';
 import { LogCategory } from '@/shared/logging/types.ts';
+import type { SaleStatus } from '@/domain/types/SaleStatus.ts';
 
 /**
  * J-League固有のデータパーサー
@@ -265,7 +266,7 @@ export class JLeagueDataParser implements IDataParser<JLeagueRawTicketData> {
     saleInfo: {
       saleStartDate?: Date;
       saleEndDate?: Date;
-      saleStatus: 'before_sale' | 'on_sale' | 'ended';
+      saleStatus: SaleStatus;
     } | null,
     _referenceDate: Date,
   ): void {

--- a/src/infrastructure/services/scraping/sources/official/hiroshima/HiroshimaConfig.ts
+++ b/src/infrastructure/services/scraping/sources/official/hiroshima/HiroshimaConfig.ts
@@ -1,0 +1,138 @@
+/**
+ * サンフレッチェ広島公式サイト スクレイピング設定
+ */
+export interface HiroshimaSchedulePageConfig {
+  selectors: {
+    ticketContainer: string[];
+    matchRow: string[];
+    matchDate: string[];
+    matchTime: string[];
+    opponent: string[];
+    venue: string[];
+    ticketStatus: string[];
+    ticketLink: string[];
+  };
+}
+
+/**
+ * サンフレッチェ広島統合設定
+ */
+export interface HiroshimaScrapingConfig {
+  baseUrl: string;
+  ticketPurchaseUrl: string;
+  schedulePageConfig: HiroshimaSchedulePageConfig;
+  awayKeywords: string[];
+  urawaKeywords: string[];
+  saleStatusKeywords: {
+    available: string[];
+    soldOut: string[];
+    notStarted: string[];
+    ended: string[];
+  };
+  timeouts: {
+    pageLoad: number;
+    elementWait: number;
+  };
+  retry: {
+    maxRetries: number;
+    baseDelay: number;
+  };
+  competitionNormalization: Record<string, string>;
+}
+
+export const HIROSHIMA_SCRAPING_CONFIG: HiroshimaScrapingConfig = {
+  baseUrl: 'https://www.sanfrecce.co.jp/tickets/schedule',
+  ticketPurchaseUrl: 'https://ticket.sanfrecce.co.jp/',
+
+  schedulePageConfig: {
+    selectors: {
+      // チケット情報を含む試合行
+      ticketContainer: [
+        'tr.cmn--btr',
+        'table tbody tr',
+      ],
+      // 個別の試合行
+      matchRow: [
+        'tr.cmn--btr',
+        'tr',
+      ],
+      // 試合日（1番目のtdから日付部分を抽出：11.9）
+      matchDate: [
+        'td:first-child p span.font-weight-bold',
+        'td:first-child p',
+      ],
+      // キックオフ時間（1番目のtdから時間部分を抽出：13:00K.O.）
+      matchTime: [
+        'td:first-child p',
+      ],
+      // 対戦相手（2番目のtdのimg alt属性）
+      opponent: [
+        'td:nth-child(2) img',
+        'td:nth-child(2) .match--item--vsteam img',
+      ],
+      // 会場（1番目のtdから会場部分を抽出）
+      venue: [
+        'td:first-child p',
+      ],
+      // チケット販売状況（8番目のtd：販売開始前）
+      ticketStatus: [
+        'td:nth-child(8) span',
+        'td:last-child span',
+        'td:nth-child(8)',
+      ],
+      // チケット詳細リンク（7番目のtd：☆☆☆）
+      ticketLink: [
+        'td:nth-child(7) a',
+      ],
+    },
+  },
+
+  // アウェイ戦識別キーワード
+  awayKeywords: ['アウェイ', 'away', 'ビジター', 'visitor'],
+
+  // 浦和レッズ識別キーワード
+  urawaKeywords: [
+    '浦和',
+    'urawa',
+    'reds',
+    '浦和レッズ',
+    'urawa reds',
+    '浦和レッドダイヤモンズ',
+    'urawa red diamonds',
+  ],
+
+  // 販売状況キーワード
+  saleStatusKeywords: {
+    available: ['販売中', '発売中', '購入可能'],
+    soldOut: ['完売', '売り切れ', '全席種完売'],
+    notStarted: ['販売開始前', '発売前', '販売予定'],
+    ended: ['販売終了', '発売終了', '終了'],
+  },
+
+  timeouts: {
+    pageLoad: 30000,
+    elementWait: 10000,
+  },
+
+  retry: {
+    maxRetries: 2,
+    baseDelay: 2000,
+  },
+
+  competitionNormalization: {
+    'J1リーグ': 'J1リーグ',
+    'J1': 'J1リーグ',
+    '明治安田Ｊ１リーグ': 'J1リーグ',
+    '明治安田J1リーグ': 'J1リーグ',
+    'ルヴァンカップ': 'ルヴァンカップ',
+    'ＹＢＣルヴァンカップ': 'ルヴァンカップ',
+    'JリーグYBCルヴァンカップ': 'ルヴァンカップ',
+    '天皇杯': '天皇杯',
+    'ＡＦＣチャンピオンズリーグエリート': 'ACLE',
+    'AFCチャンピオンズリーグエリート': 'ACLE',
+    'ＡＦＣチャンピオンズリーグ２': 'ACL2',
+    'AFCチャンピオンズリーグ2': 'ACL2',
+    'ACLE': 'ACLE',
+    'ACL2': 'ACL2',
+  } as const,
+};

--- a/src/infrastructure/services/scraping/types/ScrapedTicketData.ts
+++ b/src/infrastructure/services/scraping/types/ScrapedTicketData.ts
@@ -2,6 +2,7 @@
  * J-Leagueサイトからスクレイピングで取得されるチケット情報
  * Infrastructure層の技術的な契約として定義
  */
+import type { SaleStatus } from '@/domain/types/SaleStatus.ts';
 export interface ScrapedTicketData {
   matchName: string;
   matchDate: string | null; // 統合日時（例: "2025/09/20 19:00"）または日付のみ（例: "5/15"）
@@ -14,5 +15,5 @@ export interface ScrapedTicketData {
   homeTeam: string | null; // ホームチーム（取得できない場合はnull）
   awayTeam: string | null; // アウェイチーム（取得できない場合はnull）
   scrapedAt: Date; // スクレイピング実行時刻
-  saleStatus?: 'before_sale' | 'on_sale' | 'ended'; // 販売状態（スクレイピング失敗時はundefined）
+  saleStatus?: SaleStatus; // 販売状態（スクレイピング失敗時はundefined）
 }

--- a/src/infrastructure/types/database.ts
+++ b/src/infrastructure/types/database.ts
@@ -1,4 +1,5 @@
 import { NotificationType } from '@/domain/entities/NotificationTypes.ts';
+import type { SaleStatus } from '@/domain/types/SaleStatus.ts';
 
 export interface TicketRow {
   id: string;
@@ -15,7 +16,7 @@ export interface TicketRow {
   created_at: string;
   updated_at: string;
   scraped_at: string;
-  sale_status: 'before_sale' | 'on_sale' | 'ended';
+  sale_status: SaleStatus;
   notification_scheduled: boolean;
 }
 
@@ -45,7 +46,7 @@ export interface TicketInsert {
   ticket_types?: string[] | null;
   ticket_url?: string | null;
   scraped_at: string;
-  sale_status: 'before_sale' | 'on_sale' | 'ended';
+  sale_status: SaleStatus;
   notification_scheduled?: boolean;
 }
 

--- a/src/shared/testing/TestDataGenerator.ts
+++ b/src/shared/testing/TestDataGenerator.ts
@@ -3,6 +3,7 @@
  */
 
 import { Ticket } from '@/domain/entities/Ticket.ts';
+import type { SaleStatus } from '@/domain/types/SaleStatus.ts';
 // import { NotificationHistory } from '@/domain/entities/NotificationHistory.ts';
 // import { NotificationType } from '@/domain/entities/NotificationTypes.ts';
 
@@ -24,7 +25,7 @@ export function createTestTicket(overrides: Partial<{
   createdAt: Date;
   updatedAt: Date;
   scrapedAt: Date;
-  saleStatus?: 'before_sale' | 'on_sale' | 'ended';
+  saleStatus?: SaleStatus;
   notificationScheduled?: boolean;
 }> = {}): Ticket {
   const defaultProps = {

--- a/src/shared/utils/__tests__/errorUtils.test.ts
+++ b/src/shared/utils/__tests__/errorUtils.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStringIncludes } from 'std/testing/asserts.ts';
+import { assertEquals, assertStringIncludes } from 'std/assert/mod.ts';
 import { getErrorDetails, getErrorMessage, getErrorStack, toErrorInfo } from '../errorUtils.ts';
 
 Deno.test('getErrorMessage', async (t) => {


### PR DESCRIPTION
## 概要

サンフレッチェ広島オフィシャルサイトからの浦和レッズアウェイチケット情報自動取得機能を実装

## 実装内容

### 🏗️ 新規実装コンポーネント

- **HiroshimaScrapingService**: ISiteScrapingServiceインターフェース準拠のサービス実装
- **HiroshimaDataExtractor**: サンフレッチェ広島サイト固有のHTMLパース処理
- **HiroshimaDataParser**: 取得データの共通Ticket形式への変換処理
- **HiroshimaConfig**: サイト固有のセレクター設定とキーワード定義

### 🎯 型定義統一

- **SaleStatus型**: 販売状況の統一型定義追加（`before_sale`, `on_sale`, `sold_out`, `ended`）
- **SALE_STATUS_LABELS**: 日本語表示名の定義
- 既存のJ-LeagueパーサーとDomain層の統合対応

### 🧪 包括的テストスイート

- **単体テスト**: 全新規コンポーネントのテスト実装（20ステップ）
- **型安全性テスト**: SaleStatus型の整合性確認
- **エラーハンドリングテスト**: 異常系処理の検証

### 🔧 既存システム統合

- **DI コンテナ**: 新コンポーネントの依存性注入設定
- **型システム**: 既存インフラ層の型定義更新
- **テストユーティリティ**: 共通テストデータ生成器の更新

## テスト計画

- [x] 型チェック実行確認済み（144ファイル）
- [x] Lintチェック実行確認済み
- [x] 全テスト実行確認済み（160テスト合格）
- [x] セキュリティチェック確認済み
- [x] スクレイピング動作確認済み
- [x] 既存機能のレグレッションテスト実行済み

## アーキテクチャ準拠

✅ Clean Architecture層分離維持  
✅ 既存J-Leagueパターンとの一貫性確保  
✅ 設定外部化による保守性向上  
✅ 構造化ログによる適切なエラーハンドリング

Closes #66