### PR TITLE
Jリーグ公式サイトDOM構造変化対応 #197

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,17 +1,17 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/dotenv@0.225": "0.225.5",
+    "jsr:@std/dotenv@0.225": "0.225.6",
     "npm:@date-fns/tz@1.4.1": "1.4.1",
     "npm:@google-cloud/tasks@6.2.0": "6.2.0",
-    "npm:@supabase/supabase-js@2": "2.49.4",
+    "npm:@supabase/supabase-js@2": "2.91.0",
     "npm:date-fns@4.1.0": "4.1.0",
     "npm:fast-deep-equal@3.1.3": "3.1.3",
     "npm:playwright@1.40.0": "1.40.0"
   },
   "jsr": {
-    "@std/dotenv@0.225.5": {
-      "integrity": "9ce6f9d0ec3311f74a32535aa1b8c62ed88b1ab91b7f0815797d77a6f60c922f"
+    "@std/dotenv@0.225.6": {
+      "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
     }
   },
   "npm": {
@@ -24,22 +24,12 @@
         "google-gax"
       ]
     },
-    "@grpc/grpc-js@1.13.4": {
-      "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
+    "@grpc/grpc-js@1.14.3": {
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "dependencies": [
-        "@grpc/proto-loader@0.7.15",
+        "@grpc/proto-loader",
         "@js-sdsl/ordered-map"
       ]
-    },
-    "@grpc/proto-loader@0.7.15": {
-      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "dependencies": [
-        "lodash.camelcase",
-        "long",
-        "protobufjs",
-        "yargs"
-      ],
-      "bin": true
     },
     "@grpc/proto-loader@0.8.0": {
       "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
@@ -51,8 +41,22 @@
       ],
       "bin": true
     },
+    "@isaacs/cliui@8.0.2": {
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dependencies": [
+        "string-width@5.1.2",
+        "string-width-cjs@npm:string-width@4.2.3",
+        "strip-ansi@7.1.2",
+        "strip-ansi-cjs@npm:strip-ansi@6.0.1",
+        "wrap-ansi@8.1.0",
+        "wrap-ansi-cjs@npm:wrap-ansi@7.0.0"
+      ]
+    },
     "@js-sdsl/ordered-map@4.4.2": {
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="
+    },
+    "@pkgjs/parseargs@0.11.0": {
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="
     },
     "@protobufjs/aspromise@1.1.2": {
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
@@ -88,51 +92,45 @@
     "@protobufjs/utf8@1.1.0": {
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
-    "@supabase/auth-js@2.69.1": {
-      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+    "@supabase/auth-js@2.91.0": {
+      "integrity": "sha512-9ywvsKLsxTwv7fvN5fXzP3UfRreqrX2waylTBDu0lkmeHXa8WtSQS9e0WV9FBduiazYqQbgfBQXBNPRPsRgWOQ==",
       "dependencies": [
-        "@supabase/node-fetch"
+        "tslib"
       ]
     },
-    "@supabase/functions-js@2.4.4": {
-      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+    "@supabase/functions-js@2.91.0": {
+      "integrity": "sha512-WaakXOqLK1mLtBNFXp5o5T+LlI6KZuADSeXz+9ofPRG5OpVSvW148LVJB1DRZ16Phck1a0YqIUswOUgxCz6vMw==",
       "dependencies": [
-        "@supabase/node-fetch"
+        "tslib"
       ]
     },
-    "@supabase/node-fetch@2.6.15": {
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+    "@supabase/postgrest-js@2.91.0": {
+      "integrity": "sha512-5S41zv2euNpGucvtM4Wy+xOmLznqt/XO+Lh823LOFEQ00ov7QJfvqb6VzIxufvzhooZpmGR0BxvMcJtWxCIFdQ==",
       "dependencies": [
-        "whatwg-url"
+        "tslib"
       ]
     },
-    "@supabase/postgrest-js@1.19.4": {
-      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+    "@supabase/realtime-js@2.91.0": {
+      "integrity": "sha512-u2YuJFG35umw8DO9beC27L/jYXm3KhF+73WQwbynMpV0tXsFIA0DOGRM0NgRyy03hJIdO6mxTTwe8efW3yx3Tg==",
       "dependencies": [
-        "@supabase/node-fetch"
-      ]
-    },
-    "@supabase/realtime-js@2.11.2": {
-      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
-      "dependencies": [
-        "@supabase/node-fetch",
         "@types/phoenix",
         "@types/ws",
+        "tslib",
         "ws"
       ]
     },
-    "@supabase/storage-js@2.7.1": {
-      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+    "@supabase/storage-js@2.91.0": {
+      "integrity": "sha512-CI7fsVIBQHfNObqU9kmyQ1GWr+Ug44y4rSpvxT4LdQB9tlhg1NTBov6z7Dlmt8d6lGi/8a9lf/epCDxyWI792g==",
       "dependencies": [
-        "@supabase/node-fetch"
+        "iceberg-js",
+        "tslib"
       ]
     },
-    "@supabase/supabase-js@2.49.4": {
-      "integrity": "sha512-jUF0uRUmS8BKt37t01qaZ88H9yV1mbGYnqLeuFWLcdV+x1P4fl0yP9DGtaEhFPZcwSom7u16GkLEH9QJZOqOkw==",
+    "@supabase/supabase-js@2.91.0": {
+      "integrity": "sha512-Rjb0QqkKrmXMVwUOdEqysPBZ0ZDZakeptTkUa6k2d8r3strBdbWVDqjOdkCjAmvvZMtXecBeyTyMEXD1Zzjfvg==",
       "dependencies": [
         "@supabase/auth-js",
         "@supabase/functions-js",
-        "@supabase/node-fetch",
         "@supabase/postgrest-js",
         "@supabase/realtime-js",
         "@supabase/storage-js"
@@ -144,22 +142,22 @@
     "@types/node@24.2.0": {
       "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "dependencies": [
-        "undici-types"
+        "undici-types@7.10.0"
       ]
     },
-    "@types/phoenix@1.6.6": {
-      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
+    "@types/node@25.0.10": {
+      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+      "dependencies": [
+        "undici-types@7.16.0"
+      ]
+    },
+    "@types/phoenix@1.6.7": {
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="
     },
     "@types/ws@8.18.1": {
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dependencies": [
-        "@types/node"
-      ]
-    },
-    "abort-controller@3.0.0": {
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": [
-        "event-target-shim"
+        "@types/node@24.2.0"
       ]
     },
     "agent-base@6.0.2": {
@@ -174,11 +172,20 @@
     "ansi-regex@5.0.1": {
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
+    "ansi-regex@6.2.2": {
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
+    },
     "ansi-styles@4.3.0": {
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": [
         "color-convert"
       ]
+    },
+    "ansi-styles@6.2.3": {
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="
+    },
+    "balanced-match@1.0.2": {
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js@1.5.1": {
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
@@ -186,15 +193,21 @@
     "bignumber.js@9.3.1": {
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
     },
+    "brace-expansion@2.0.2": {
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dependencies": [
+        "balanced-match"
+      ]
+    },
     "buffer-equal-constant-time@1.0.1": {
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "cliui@8.0.1": {
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": [
-        "string-width",
-        "strip-ansi",
-        "wrap-ansi"
+        "string-width@4.2.3",
+        "strip-ansi@6.0.1",
+        "wrap-ansi@7.0.0"
       ]
     },
     "color-convert@2.0.1": {
@@ -206,14 +219,22 @@
     "color-name@1.1.4": {
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "cross-spawn@7.0.6": {
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": [
+        "path-key",
+        "shebang-command",
+        "which"
+      ]
+    },
     "data-uri-to-buffer@4.0.1": {
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
     },
     "date-fns@4.1.0": {
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
-    "debug@4.4.1": {
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": [
         "ms"
       ]
@@ -227,6 +248,9 @@
         "stream-shift"
       ]
     },
+    "eastasianwidth@0.2.0": {
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
     "ecdsa-sig-formatter@1.0.11": {
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "dependencies": [
@@ -236,6 +260,9 @@
     "emoji-regex@8.0.0": {
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "emoji-regex@9.2.2": {
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
     "end-of-stream@1.4.5": {
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dependencies": [
@@ -244,9 +271,6 @@
     },
     "escalade@3.2.0": {
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
-    },
-    "event-target-shim@5.0.1": {
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "extend@3.0.2": {
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
@@ -261,6 +285,13 @@
         "web-streams-polyfill"
       ]
     },
+    "foreground-child@3.3.1": {
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dependencies": [
+        "cross-spawn",
+        "signal-exit"
+      ]
+    },
     "formdata-polyfill@4.0.10": {
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dependencies": [
@@ -272,16 +303,17 @@
       "os": ["darwin"],
       "scripts": true
     },
-    "gaxios@7.1.1": {
-      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
+    "gaxios@7.1.3": {
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
       "dependencies": [
         "extend",
         "https-proxy-agent@7.0.6",
-        "node-fetch"
+        "node-fetch",
+        "rimraf"
       ]
     },
-    "gcp-metadata@7.0.1": {
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+    "gcp-metadata@8.1.2": {
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "dependencies": [
         "gaxios",
         "google-logging-utils",
@@ -291,8 +323,20 @@
     "get-caller-file@2.0.5": {
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
-    "google-auth-library@10.3.0": {
-      "integrity": "sha512-ylSE3RlCRZfZB56PFJSfUCuiuPq83Fx8hqu1KPWGK8FVdSaxlp/qkeMMX/DT/18xkwXIHvXEXkZsljRwfrdEfQ==",
+    "glob@10.5.0": {
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "dependencies": [
+        "foreground-child",
+        "jackspeak",
+        "minimatch",
+        "minipass",
+        "package-json-from-dist",
+        "path-scurry"
+      ],
+      "bin": true
+    },
+    "google-auth-library@10.5.0": {
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
       "dependencies": [
         "base64-js",
         "ecdsa-sig-formatter",
@@ -303,12 +347,11 @@
         "jws"
       ]
     },
-    "google-gax@5.0.3": {
-      "integrity": "sha512-DkWybwgkV8HA9aIizNEHEUHd8ho1BzGGQ/YMGDsTt167dQ8pk/oMiwxpUFvh6Ta93m8ZN7KwdWmP3o46HWjV+A==",
+    "google-gax@5.0.6": {
+      "integrity": "sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==",
       "dependencies": [
         "@grpc/grpc-js",
-        "@grpc/proto-loader@0.8.0",
-        "abort-controller",
+        "@grpc/proto-loader",
         "duplexify",
         "google-auth-library",
         "google-logging-utils",
@@ -316,11 +359,12 @@
         "object-hash",
         "proto3-json-serializer",
         "protobufjs",
-        "retry-request"
+        "retry-request",
+        "rimraf"
       ]
     },
-    "google-logging-utils@1.1.1": {
-      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A=="
+    "google-logging-utils@1.1.3": {
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="
     },
     "gtoken@8.0.0": {
       "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
@@ -351,11 +395,26 @@
         "debug"
       ]
     },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-fullwidth-code-point@3.0.0": {
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "isexe@2.0.0": {
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "jackspeak@3.4.3": {
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dependencies": [
+        "@isaacs/cliui"
+      ],
+      "optionalDependencies": [
+        "@pkgjs/parseargs"
+      ]
     },
     "json-bigint@1.0.0": {
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
@@ -371,8 +430,8 @@
         "safe-buffer"
       ]
     },
-    "jws@4.0.0": {
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+    "jws@4.0.1": {
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "dependencies": [
         "jwa",
         "safe-buffer"
@@ -383,6 +442,18 @@
     },
     "long@5.3.2": {
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+    },
+    "lru-cache@10.4.3": {
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "minimatch@9.0.5": {
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": [
+        "brace-expansion"
+      ]
+    },
+    "minipass@7.1.2": {
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
     },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
@@ -408,6 +479,19 @@
         "wrappy"
       ]
     },
+    "package-json-from-dist@1.0.1": {
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+    },
+    "path-key@3.1.1": {
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-scurry@1.11.1": {
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dependencies": [
+        "lru-cache",
+        "minipass"
+      ]
+    },
     "playwright-core@1.40.0": {
       "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
       "bin": true
@@ -422,8 +506,8 @@
       ],
       "bin": true
     },
-    "proto3-json-serializer@3.0.2": {
-      "integrity": "sha512-AnMIfnoK2Ml3F/ZVl5PxcwIoefMxj4U/lomJ5/B2eIGdxw4UkbV1YamtsMQsEkZATdMCKMbnI1iG9RQaJbxBGw==",
+    "proto3-json-serializer@3.0.4": {
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
       "dependencies": [
         "protobufjs"
       ]
@@ -441,7 +525,7 @@
         "@protobufjs/path",
         "@protobufjs/pool",
         "@protobufjs/utf8",
-        "@types/node",
+        "@types/node@25.0.10",
         "long"
       ],
       "scripts": true
@@ -464,8 +548,27 @@
         "teeny-request"
       ]
     },
+    "rimraf@5.0.10": {
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dependencies": [
+        "glob"
+      ],
+      "bin": true
+    },
     "safe-buffer@5.2.1": {
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "shebang-command@2.0.0": {
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": [
+        "shebang-regex"
+      ]
+    },
+    "shebang-regex@3.0.0": {
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "signal-exit@4.1.0": {
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
     "stream-events@1.0.5": {
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
@@ -479,9 +582,17 @@
     "string-width@4.2.3": {
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": [
-        "emoji-regex",
+        "emoji-regex@8.0.0",
         "is-fullwidth-code-point",
-        "strip-ansi"
+        "strip-ansi@6.0.1"
+      ]
+    },
+    "string-width@5.1.2": {
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": [
+        "eastasianwidth",
+        "emoji-regex@9.2.2",
+        "strip-ansi@7.1.2"
       ]
     },
     "string_decoder@1.3.0": {
@@ -493,7 +604,13 @@
     "strip-ansi@6.0.1": {
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": [
-        "ansi-regex"
+        "ansi-regex@5.0.1"
+      ]
+    },
+    "strip-ansi@7.1.2": {
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dependencies": [
+        "ansi-regex@6.2.2"
       ]
     },
     "stubs@3.0.0": {
@@ -508,11 +625,14 @@
         "stream-events"
       ]
     },
-    "tr46@0.0.3": {
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "undici-types@7.10.0": {
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
+    },
+    "undici-types@7.16.0": {
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
     },
     "util-deprecate@1.0.2": {
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
@@ -520,29 +640,34 @@
     "web-streams-polyfill@3.3.3": {
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
     },
-    "webidl-conversions@3.0.1": {
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url@5.0.0": {
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+    "which@2.0.2": {
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": [
-        "tr46",
-        "webidl-conversions"
-      ]
+        "isexe"
+      ],
+      "bin": true
     },
     "wrap-ansi@7.0.0": {
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dependencies": [
-        "ansi-styles",
-        "string-width",
-        "strip-ansi"
+        "ansi-styles@4.3.0",
+        "string-width@4.2.3",
+        "strip-ansi@6.0.1"
+      ]
+    },
+    "wrap-ansi@8.1.0": {
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dependencies": [
+        "ansi-styles@6.2.3",
+        "string-width@5.1.2",
+        "strip-ansi@7.1.2"
       ]
     },
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "ws@8.18.2": {
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="
+    "ws@8.19.0": {
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="
     },
     "y18n@5.0.8": {
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
@@ -557,7 +682,7 @@
         "escalade",
         "get-caller-file",
         "require-directory",
-        "string-width",
+        "string-width@4.2.3",
         "y18n",
         "yargs-parser"
       ]

--- a/docs/issue-priority-roadmap.md
+++ b/docs/issue-priority-roadmap.md
@@ -2,8 +2,7 @@
 
 **Target**: Personal use MVP with minimal implementation\
 **Created**: 2025-08-22\
-**Updated**: 2026-01-03 (最新状況: #171 Cloud Tasks Emulator実装完了、#193
-自動クリーンアップ実装完了)\
+**Updated**: 2026-01-22 (最新状況: #197 Jリーグ公式サイトDOM構造変化対応 - NEW バグ)\
 **Goal**: ✅ Launch MVP by 2025-09-30 (**完了**: 2025-09-16)
 
 ## Implementation Status Summary
@@ -251,6 +250,7 @@ Each issue is considered complete when:
 
 | Issue | Title                                                                | Category           | Priority    | Status           |
 | ----- | -------------------------------------------------------------------- | ------------------ | ----------- | ---------------- |
+| #197  | Jリーグ公式サイトのDOM構造変化に対応                                 | スクレイピングバグ | 🔴 Critical | 🚨 **OPEN**      |
 | #184  | collect-ticketがエラー                                               | スクレイピングバグ | 🔴 Critical | ✅ **COMPLETED** |
 | #182  | Ticket Entityのupsert改善：既存値保持と差分更新ロジックの実装        | 機能改善           | 🟠 High     | ✅ **COMPLETED** |
 | #179  | [BUG] サンフレッチェ広島のチケット販売状況が「発売中」に更新されない | スクレイピングバグ | 🔴 Critical | ✅ **COMPLETED** |
@@ -295,18 +295,25 @@ Each issue is considered complete when:
 | #67   | ヴィッセル神戸対応                               | 他チーム対応    | 🔄 **DEFERRED** (2026年1-2月実装) |
 | #105  | 2026年シーズン制度変更対応                       | 長期計画        | 🔄 **DEFERRED** (2026年2月まで)   |
 
-## Next Steps Priority (**UPDATED: 2026-01-03**)
+## Next Steps Priority (**UPDATED: 2026-01-22**)
 
 ### 🎯 **推奨実装順序**
 
+#### 📍 **最優先タスク** (バグ修正)
+
+1. **#197** - Jリーグ公式サイトのDOM構造変化に対応 🔴 **CRITICAL**
+   - **内容**: Jリーグ公式サイトのDOM構造変更によるスクレイピング失敗の修正
+   - **影響**: チケット情報取得機能が動作しない可能性
+   - **期待効果**: スクレイピング機能の復旧
+
 #### 📍 **最近完了**
 
-- **#171** - 開発環境でのCloudTasksモック実装 ✅ **COMPLETED** (2025-12-22)
-  - **内容**: ローカル開発環境でのCloud Tasks Emulator機能実装
-  - **効果**: 開発効率改善・テスト環境統一
 - **#193** - データベースレコードの自動クリーンアップ機能実装 ✅ **COMPLETED**
   - **内容**: tickets (試合日+30日後) / notifications (送信+90日後) の自動削除
   - **効果**: データベース肥大化防止・運用コスト削減
+- **#171** - 開発環境でのCloudTasksモック実装 ✅ **COMPLETED** (2025-12-22)
+  - **内容**: ローカル開発環境でのCloud Tasks Emulator機能実装
+  - **効果**: 開発効率改善・テスト環境統一
 
 #### 📍 **中優先タスク** (運用改善・パフォーマンス)
 

--- a/src/infrastructure/services/scraping/sources/jleague/JLeagueConfig.ts
+++ b/src/infrastructure/services/scraping/sources/jleague/JLeagueConfig.ts
@@ -19,15 +19,17 @@ export interface JLeagueListPageConfig {
  */
 export interface JLeagueDetailPageConfig {
   selectors: {
+    // 試合情報用
     matchNameAndCompetition: string; // '.game-info-ttl'
     matchDateTime: string; // '.game-info-day'
     dateElement: string; // '.day:first-child'
     timeElement: string; // '.day:nth-child(2)'
-    visitorSections: string; // 'dt'
-    sectionTitle: string; // '.seat-select-list-txt h4'
-    saleInfoContainer: string; // 'li'
-    saleInfoTitle: string; // 'h5'
-    saleInfoContent: string; // '.list-items-cts-desc dd'
+    // 新DOM構造用（2026年1月〜）
+    listWrap: string; // '.list-wrap'
+    infoScheduleItem: string; // '.info-schedule-list .item'
+    scheduleItemTitle: string; // '.title'
+    scheduleItemDate: string; // '.date'
+    ticketType: string; // '.list-items-cts-desc h5'
   };
 }
 
@@ -98,15 +100,17 @@ export const J_LEAGUE_SCRAPING_CONFIG: JLeagueScrapingConfig = {
   },
   detailPage: {
     selectors: {
+      // 試合情報用
       matchNameAndCompetition: '.game-info-ttl',
       matchDateTime: '.game-info-day',
       dateElement: '.day:first-child',
       timeElement: '.day:nth-child(2)',
-      visitorSections: 'dt',
-      sectionTitle: '.seat-select-list-txt h4',
-      saleInfoContainer: 'li',
-      saleInfoTitle: 'h5',
-      saleInfoContent: '.list-items-cts-desc dd',
+      // 新DOM構造用（2026年1月〜）
+      listWrap: '.list-wrap',
+      infoScheduleItem: '.info-schedule-list .item',
+      scheduleItemTitle: '.title',
+      scheduleItemDate: '.date',
+      ticketType: '.list-items-cts-desc h5',
     },
   },
 

--- a/tests/fixtures/sample-ticket-page.html
+++ b/tests/fixtures/sample-ticket-page.html
@@ -180,83 +180,122 @@
       </ul>
     </div>
 
-    <!-- チケット詳細ページのサンプル -->
+    <!-- チケット詳細ページのサンプル（新DOM構造 2026年1月〜） -->
     <div class="seat-select-list" style="display: none">
       <!-- ビジター席 -->
-      <dl>
-        <dt>
-          <div class="seat-select-list-img bg-pre">
-            <img src="/img/ico_pre2.png" alt="">
+      <div class="list-wrap">
+        <div class="info-box js-info-box">
+          <div class="info-btn">
+            <span class="info-text">
+              <span>発売</span>
+              <span>情報</span>
+            </span>
           </div>
-          <div class="seat-select-list-txt">
-            <h4>ビジター１Ｆ指定席</h4>
-            <p>2000円/枚～5000円/枚</p>
-            <p class="label"><span class="c-select">指定</span></p>
+          <div class="info-detail">
+            <div class="info-schedule-list">
+              <div class="item">
+                <div class="title">【ゴールド会員以上】優先先行／ＱＲチケット（Ｊチケ）</div>
+                <div class="date">〜08/10(金)23:59</div>
+              </div>
+              <div class="item">
+                <div class="title">【レギュラー会員】先行／ＱＲチケット（Ｊチケ）</div>
+                <div class="date">08/12(金)12:00〜</div>
+              </div>
+              <div class="item">
+                <div class="title">一般発売／ＱＲチケット（Ｊチケ）</div>
+                <div class="date">08/15(金)10:00〜</div>
+              </div>
+              <div class="item">
+                <div class="title">一般発売／店頭発券（Ｊチケ）</div>
+                <div class="date">08/15(金)10:00〜</div>
+              </div>
+            </div>
           </div>
-          <div class="opener"></div>
-        </dt>
-        <dd>
+        </div>
+        <div class="list-items-wrap">
           <div class="list-items">
-            <p class="list-items-ttl">東サイドスタンド</p>
             <div class="list-items-cts">
               <ul>
                 <li class="pre">
                   <a href="javascript:void(0);" class="nolink">
                     <img src="/img/ico_pre.png" alt="">
                     <div class="list-items-cts-desc">
-                      <h5>一般発売／ＱＲチケット（パルチケ）</h5>
-                      <p>
-                        2000円/枚～5000円/枚&nbsp;&nbsp;<span class="c-select">指定</span>&nbsp;
-                      </p>
-                      <dl>
-                        <dt>発売期間</dt>
-                        <dd>08/15(金)10:00〜</dd>
-                      </dl>
+                      <h5>ビジター１Ｆ指定席</h5>
                     </div>
+                    <div class="list-items-cts-ticket"></div>
                   </a>
                 </li>
               </ul>
             </div>
           </div>
-        </dd>
-      </dl>
+        </div>
+      </div>
 
       <!-- アウェイ自由席 -->
-      <dl>
-        <dt>
-          <div class="seat-select-list-img bg-vacant">
-            <img src="/img/ico_vacant2.png" alt="">
+      <div class="list-wrap">
+        <div class="info-box js-info-box">
+          <div class="info-btn">
+            <span class="info-text">
+              <span>発売</span>
+              <span>情報</span>
+            </span>
           </div>
-          <div class="seat-select-list-txt">
-            <h4>アウェイ自由席</h4>
-            <p>1500円/枚～3000円/枚</p>
-            <p class="label"><span class="c-free">自由</span></p>
+          <div class="info-detail">
+            <div class="info-schedule-list">
+              <div class="item">
+                <div class="title">一般発売／ＱＲチケット（Ｊチケ）</div>
+                <div class="date">08/20(金)10:00〜</div>
+              </div>
+            </div>
           </div>
-          <div class="opener"></div>
-        </dt>
-        <dd>
+        </div>
+        <div class="list-items-wrap">
           <div class="list-items">
-            <p class="list-items-ttl">ゴール裏</p>
             <div class="list-items-cts">
               <ul>
                 <li class="vacant">
                   <a href="javascript:void(0);">
                     <img src="/img/ico_vacant.png" alt="">
                     <div class="list-items-cts-desc">
-                      <h5>一般発売／ＱＲチケット</h5>
-                      <p>1500円/枚&nbsp;&nbsp;<span class="c-free">自由</span>&nbsp;</p>
-                      <dl>
-                        <dt>発売期間</dt>
-                        <dd>08/20(金)10:00〜09/22(月)23:59</dd>
-                      </dl>
+                      <h5>アウェイ自由席</h5>
+                    </div>
+                    <div class="list-items-cts-ticket"></div>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ホーム席（フィルター対象外） -->
+      <div class="list-wrap">
+        <div class="info-box js-info-box">
+          <div class="info-detail">
+            <div class="info-schedule-list">
+              <div class="item">
+                <div class="title">一般発売／ＱＲチケット（Ｊチケ）</div>
+                <div class="date">08/15(金)10:00〜</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="list-items-wrap">
+          <div class="list-items">
+            <div class="list-items-cts">
+              <ul>
+                <li class="vacant">
+                  <a href="javascript:void(0);">
+                    <div class="list-items-cts-desc">
+                      <h5>ホーム自由席</h5>
                     </div>
                   </a>
                 </li>
               </ul>
             </div>
           </div>
-        </dd>
-      </dl>
+        </div>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## 概要

- Jリーグ公式チケットサイトの2026年1月DOM構造変更に対応
- 詳細ページの座席種別・発売日時取得ロジックを新構造に適応

## 実装内容

### JLeagueConfig.ts
- 新DOM構造用セレクターを定義
  - `.list-wrap`: 座席情報コンテナ
  - `.info-schedule-list .item`: 発売スケジュール項目
  - `.list-items-cts-desc h5`: 座席種別名
- 旧セレクター（`visitorSections`, `sectionTitle`等）を削除

### JLeagueScrapingService.ts
- `extractTicketDetailsFromPage`メソッドを新DOM構造に対応
- アコーディオンクリック不要な新構造への対応
- 一般発売日時の抽出ロジック改善（先行販売を除外）
- `playwright`のElementHandle型インポートを削除（不要になったため）

### テスト
- 新DOM構造対応のユニットテストを追加
- テストフィクスチャ（sample-ticket-page.html）を新DOM構造に更新

## テスト計画

- [x] `deno check` 型チェック成功
- [x] `deno fmt` フォーマット適用
- [x] ユニットテスト全13ステップ成功
- [ ] 本番環境での動作確認

Closes #197