### PR TITLE
Jリーグ詳細ページのDOM構造変更に対応（.day/.time分離） #200

### DIFF
--- a/src/infrastructure/services/scraping/sources/jleague/JLeagueConfig.ts
+++ b/src/infrastructure/services/scraping/sources/jleague/JLeagueConfig.ts
@@ -22,9 +22,8 @@ export interface JLeagueDetailPageConfig {
     // 試合情報用
     matchNameAndCompetition: string; // '.game-info-ttl'
     matchDateTime: string; // '.game-info-day'
-    dateElement: string; // '.day:first-child'
-    timeElement: string; // '.day:nth-child(2)'
-    // 新DOM構造用（2026年1月〜）
+    dateElement: string; // '.day'
+    timeElement: string; // '.time'
     listWrap: string; // '.list-wrap'
     infoScheduleItem: string; // '.info-schedule-list .item'
     scheduleItemTitle: string; // '.title'
@@ -103,8 +102,8 @@ export const J_LEAGUE_SCRAPING_CONFIG: JLeagueScrapingConfig = {
       // 試合情報用
       matchNameAndCompetition: '.game-info-ttl',
       matchDateTime: '.game-info-day',
-      dateElement: '.day:first-child',
-      timeElement: '.day:nth-child(2)',
+      dateElement: '.day',
+      timeElement: '.time',
       // 新DOM構造用（2026年1月〜）
       listWrap: '.list-wrap',
       infoScheduleItem: '.info-schedule-list .item',

--- a/src/infrastructure/services/scraping/sources/jleague/JLeagueScrapingService.ts
+++ b/src/infrastructure/services/scraping/sources/jleague/JLeagueScrapingService.ts
@@ -207,13 +207,19 @@ export class JLeagueScrapingService implements ISiteScrapingService {
         J_LEAGUE_SCRAPING_CONFIG.detailPage.selectors.matchDateTime,
       );
       if (dateTimeElement) {
-        const dayElements = await dateTimeElement.$$('.day');
-        if (dayElements.length >= 2) {
-          const dateText = await dayElements[0].textContent();
-          const timeText = await dayElements[1].textContent();
-          if (dateText?.trim() && timeText?.trim()) {
-            enhancedMatchDateTime = `${dateText.trim()} ${timeText.trim()}`;
-          }
+        // 日付要素（.day）と時刻要素（.time）を個別に取得
+        const dateElement = await dateTimeElement.$(
+          J_LEAGUE_SCRAPING_CONFIG.detailPage.selectors.dateElement,
+        );
+        const timeElement = await dateTimeElement.$(
+          J_LEAGUE_SCRAPING_CONFIG.detailPage.selectors.timeElement,
+        );
+
+        const dateText = dateElement ? await dateElement.textContent() : null;
+        const timeText = timeElement ? await timeElement.textContent() : null;
+
+        if (dateText?.trim() && timeText?.trim()) {
+          enhancedMatchDateTime = `${dateText.trim()} ${timeText.trim()}`;
         }
       }
     } catch (_error) {


### PR DESCRIPTION
## 概要

- Jリーグ公式サイトの詳細ページにおけるDOM構造変更に対応

## 実装内容

- `JLeagueConfig.ts`: セレクタを新しいDOM構造に合わせて更新
  - `dateElement`: `.day:first-child` → `.day`
  - `timeElement`: `.day:nth-child(2)` → `.time`
- `JLeagueScrapingService.ts`: 日付・時刻要素の取得ロジックを修正
  - `.day`クラスの複数要素から取得 → `.day`と`.time`を個別に取得
  - 設定ファイルのセレクタを参照するように統一

## テスト計画

- [ ] 型チェック確認済み
- [ ] Lint確認済み
- [ ] 実際のJリーグサイトでスクレイピング動作確認

Closes #200